### PR TITLE
fix: resolve TypeScript build errors

### DIFF
--- a/src/agents/xiaomimo-web-stream.ts
+++ b/src/agents/xiaomimo-web-stream.ts
@@ -465,10 +465,11 @@ export function createXiaomiMimoWebStreamFn(cookieOrJson: string): StreamFn {
         }
 
         if (tagBuffer) {
+          const currentModeValue = currentMode as "text" | "thinking" | "tool_call";
           const mode =
-            currentMode === "thinking"
+            currentModeValue === "thinking"
               ? "thinking"
-              : currentMode === "tool_call"
+              : currentModeValue === "tool_call"
                 ? "toolcall"
                 : "text";
           emitDelta(mode, tagBuffer);

--- a/src/commands/onboard-web-auth.ts
+++ b/src/commands/onboard-web-auth.ts
@@ -27,6 +27,7 @@ import { loginQwenCNWeb } from "../providers/qwen-cn-web-auth.js";
 import { loginQwenWeb } from "../providers/qwen-web-auth.js";
 import { loginXiaomiMimoWeb } from "../providers/xiaomimo-web-auth.js";
 import type { WizardStep } from "../wizard/types.js";
+import { applyAgentDefaultModelPrimary } from "./onboard-auth.config-shared.js";
 
 // Web 模型凭证保存助手函数
 async function saveWebModelCredentials(providerId: string, credentials: unknown): Promise<void> {


### PR DESCRIPTION
## Summary

This PR fixes two TypeScript build errors:

### 1. xiaomimo-web-stream.ts: Type assertion for closure variable

**Problem**: TypeScript control flow analysis cannot track variable mutations inside closures. The `currentMode` variable is modified by nested functions (`checkTags`, `processLine`), but TypeScript narrows its type to `"text"` at the usage site.

**Fix**: Added explicit type assertion to help the compiler understand the union type:
```typescript
const currentModeValue = currentMode as "text" | "thinking" | "tool_call";
```

### 2. onboard-web-auth.ts: Missing import

**Problem**: `applyAgentDefaultModelPrimary` function was used but not imported, causing `ReferenceError: applyAgentDefaultModelPrimary is not defined` at runtime.

**Fix**: Added the missing import:
```typescript
import { applyAgentDefaultModelPrimary } from "./onboard-auth.config-shared.js";
```

## Test plan

- [x] Run `pnpm build` - should complete without TypeScript errors
- [x] Verify `dist/` output is generated correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **重构**
  * 改进了流处理逻辑的类型安全性和比较操作。

* **杂务**
  * 优化了配置初始化流程，在启动时自动检测并应用首个可用的默认AI代理模型。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->