### PR TITLE
fix(build): track startup advisory and reflection sources

### DIFF
--- a/src/agents/runtime-reflection.test.ts
+++ b/src/agents/runtime-reflection.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  loadRecentRuntimeReflections,
+  writeRuntimeReflection,
+  type RuntimeReflectionRecord,
+} from "./runtime-reflection.js";
+
+async function withTempDir(run: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "runtime-reflection-"));
+  try {
+    await run(dir);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+}
+
+describe("runtime reflections", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("writes a reflection artifact into the dated surface directory", async () => {
+    await withTempDir(async (dir) => {
+      vi.stubEnv("OPENCLAW_RUNTIME_REFLECTIONS_ROOT", dir);
+
+      const written = await writeRuntimeReflection({
+        surface: "cron",
+        entityId: "daily-knowledge-archiver",
+        sessionKey: "agent:ops:main",
+        taskShape: "debug_runtime",
+        claimedOutcome: "core_success",
+        observedOutcome: "partial_delivery_failure",
+        claimMismatch: true,
+        sourceRefs: ["cron:Daily Knowledge Archiver", "runs/daily.jsonl"],
+        benchmarkTags: ["cron-triage", "honest-outcome"],
+        operatorActionable: "Check delivery target and rerun only after confirming announce path.",
+        createdAt: "2026-03-24T10:00:00.000Z",
+      });
+
+      expect(written.record.id).toContain("cron-daily-knowledge-archiver");
+      expect(written.path).toContain(path.join("2026-03-24", "cron"));
+
+      const raw = JSON.parse(await fs.readFile(written.path, "utf8")) as RuntimeReflectionRecord;
+      expect(raw.surface).toBe("cron");
+      expect(raw.claimMismatch).toBe(true);
+      expect(raw.benchmarkTags).toContain("cron-triage");
+    });
+  });
+
+  it("loads recent reflections, filters by age, and sorts newest first", async () => {
+    await withTempDir(async (dir) => {
+      vi.stubEnv("OPENCLAW_RUNTIME_REFLECTIONS_ROOT", dir);
+      const nowMs = Date.parse("2026-03-24T12:00:00.000Z");
+
+      await writeRuntimeReflection({
+        surface: "startup_advisory",
+        entityId: "agent-main",
+        sessionKey: "agent:main:main",
+        taskShape: "skill_routing_policy",
+        claimedOutcome: "fresh_ready",
+        observedOutcome: "cached_advisory",
+        sourceRefs: ["agent:main:main"],
+        benchmarkTags: ["startup-advisory"],
+        operatorActionable: "Wait for background refresh before trusting auto-attach.",
+        createdAt: "2026-03-24T11:30:00.000Z",
+      });
+      await writeRuntimeReflection({
+        surface: "timeline_intel",
+        entityId: "home_timeline",
+        claimedOutcome: "top_item_candidate",
+        observedOutcome: "rejected_hype_noise",
+        sourceRefs: ["x_timeline_20260324_113000.json"],
+        benchmarkTags: ["001-timeline-intel"],
+        operatorActionable: "Keep freshness-first lane and reject hype-only tweets.",
+        createdAt: "2026-03-24T11:50:00.000Z",
+      });
+      await writeRuntimeReflection({
+        surface: "memory_operator",
+        entityId: "mem-legacy",
+        claimedOutcome: "edited",
+        observedOutcome: "edited",
+        sourceRefs: ["op-old"],
+        benchmarkTags: ["memory-operator"],
+        operatorActionable: "Legacy sample.",
+        createdAt: "2026-03-23T00:00:00.000Z",
+      });
+
+      const recent = await loadRecentRuntimeReflections({ nowMs, windowMs: 6 * 60 * 60_000 });
+      expect(recent.map((entry) => entry.record.surface)).toEqual([
+        "timeline_intel",
+        "startup_advisory",
+      ]);
+      expect(recent[0]?.record.id).toContain("timeline-intel-home-timeline");
+    });
+  });
+});

--- a/src/agents/runtime-reflection.ts
+++ b/src/agents/runtime-reflection.ts
@@ -1,0 +1,245 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+export const DEFAULT_RUNTIME_REFLECTIONS_ROOT =
+  "/Users/lixun/.openclaw/workspace/artifacts/self-improve";
+
+export type RuntimeReflectionSurface =
+  | "cron"
+  | "startup_advisory"
+  | "memory_operator"
+  | "timeline_intel";
+
+export type RuntimeReflectionRecord = {
+  version: 1;
+  id: string;
+  surface: RuntimeReflectionSurface;
+  entityId: string;
+  sessionKey?: string;
+  taskShape?: string;
+  claimedOutcome: string;
+  observedOutcome: string;
+  claimMismatch?: boolean;
+  recoveryKind?: string;
+  sourceRefs: string[];
+  benchmarkTags: string[];
+  operatorActionable: string;
+  createdAt: string;
+  metadata?: Record<string, unknown>;
+};
+
+export type RuntimeReflectionWriteInput = Omit<RuntimeReflectionRecord, "version" | "id"> & {
+  id?: string;
+};
+
+export type RuntimeReflectionArtifact = {
+  path: string;
+  record: RuntimeReflectionRecord;
+};
+
+function resolveRuntimeReflectionsRoot(): string {
+  return (
+    process.env.OPENCLAW_RUNTIME_REFLECTIONS_ROOT?.trim() || DEFAULT_RUNTIME_REFLECTIONS_ROOT
+  );
+}
+
+function slugify(value: string): string {
+  const cleaned = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return cleaned || "artifact";
+}
+
+function normalizeRefs(values: string[] | undefined): string[] {
+  return Array.from(
+    new Set((values ?? []).map((value) => value.trim()).filter(Boolean)),
+  );
+}
+
+function resolveCreatedAt(value?: string): string {
+  const createdAt = value?.trim() || new Date().toISOString();
+  const parsed = Date.parse(createdAt);
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`Invalid runtime reflection createdAt: ${value}`);
+  }
+  return new Date(parsed).toISOString();
+}
+
+function buildRuntimeReflectionId(
+  surface: RuntimeReflectionSurface,
+  entityId: string,
+  createdAt: string,
+): string {
+  const stamp = createdAt.replace(/[-:.TZ]/g, "").slice(0, 17);
+  return `${surface.replace(/_/g, "-")}-${slugify(entityId)}-${stamp}`;
+}
+
+function resolveRuntimeReflectionPath(record: RuntimeReflectionRecord): string {
+  const datePart = record.createdAt.slice(0, 10);
+  return path.join(
+    resolveRuntimeReflectionsRoot(),
+    datePart,
+    record.surface,
+    `${record.id}.json`,
+  );
+}
+
+async function resolveUniqueRuntimeReflectionArtifact(record: RuntimeReflectionRecord): Promise<{
+  record: RuntimeReflectionRecord;
+  path: string;
+}> {
+  let nextRecord = record;
+  let filePath = resolveRuntimeReflectionPath(nextRecord);
+  let suffix = 2;
+  while (true) {
+    try {
+      await fs.access(filePath);
+      nextRecord = { ...record, id: `${record.id}-${suffix}` };
+      filePath = resolveRuntimeReflectionPath(nextRecord);
+      suffix += 1;
+    } catch {
+      return { record: nextRecord, path: filePath };
+    }
+  }
+}
+
+export async function writeRuntimeReflection(
+  input: RuntimeReflectionWriteInput,
+): Promise<RuntimeReflectionArtifact> {
+  const createdAt = resolveCreatedAt(input.createdAt);
+  const record: RuntimeReflectionRecord = {
+    version: 1,
+    id: input.id?.trim() || buildRuntimeReflectionId(input.surface, input.entityId, createdAt),
+    surface: input.surface,
+    entityId: input.entityId.trim(),
+    sessionKey: input.sessionKey?.trim() || undefined,
+    taskShape: input.taskShape?.trim() || undefined,
+    claimedOutcome: input.claimedOutcome.trim(),
+    observedOutcome: input.observedOutcome.trim(),
+    claimMismatch: input.claimMismatch === true ? true : undefined,
+    recoveryKind: input.recoveryKind?.trim() || undefined,
+    sourceRefs: normalizeRefs(input.sourceRefs),
+    benchmarkTags: normalizeRefs(input.benchmarkTags),
+    operatorActionable: input.operatorActionable.trim(),
+    createdAt,
+    metadata: input.metadata,
+  };
+  const { record: uniqueRecord, path: filePath } =
+    await resolveUniqueRuntimeReflectionArtifact(record);
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, `${JSON.stringify(uniqueRecord, null, 2)}\n`, "utf8");
+  return { path: filePath, record: uniqueRecord };
+}
+
+function parseReflectionRecord(raw: string, filePath: string): RuntimeReflectionRecord | null {
+  try {
+    const parsed = JSON.parse(raw) as Partial<RuntimeReflectionRecord> | null;
+    if (!parsed || parsed.version !== 1 || typeof parsed.id !== "string") {
+      return null;
+    }
+    if (
+      typeof parsed.surface !== "string" ||
+      typeof parsed.entityId !== "string" ||
+      typeof parsed.claimedOutcome !== "string" ||
+      typeof parsed.observedOutcome !== "string" ||
+      typeof parsed.operatorActionable !== "string" ||
+      typeof parsed.createdAt !== "string"
+    ) {
+      return null;
+    }
+    const createdAt = resolveCreatedAt(parsed.createdAt);
+    return {
+      version: 1,
+      id: parsed.id,
+      surface: parsed.surface as RuntimeReflectionSurface,
+      entityId: parsed.entityId,
+      sessionKey: typeof parsed.sessionKey === "string" ? parsed.sessionKey : undefined,
+      taskShape: typeof parsed.taskShape === "string" ? parsed.taskShape : undefined,
+      claimedOutcome: parsed.claimedOutcome,
+      observedOutcome: parsed.observedOutcome,
+      claimMismatch: parsed.claimMismatch === true ? true : undefined,
+      recoveryKind: typeof parsed.recoveryKind === "string" ? parsed.recoveryKind : undefined,
+      sourceRefs: normalizeRefs(Array.isArray(parsed.sourceRefs) ? parsed.sourceRefs : []),
+      benchmarkTags: normalizeRefs(Array.isArray(parsed.benchmarkTags) ? parsed.benchmarkTags : []),
+      operatorActionable: parsed.operatorActionable,
+      createdAt,
+      metadata:
+        parsed.metadata && typeof parsed.metadata === "object"
+          ? (parsed.metadata as Record<string, unknown>)
+          : undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function walkJsonFiles(root: string): Promise<string[]> {
+  const pending = [root];
+  const results: string[] = [];
+  while (pending.length > 0) {
+    const current = pending.pop();
+    if (!current) {
+      continue;
+    }
+    let entries;
+    try {
+      entries = await fs.readdir(current, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      const nextPath = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        pending.push(nextPath);
+      } else if (entry.isFile() && entry.name.endsWith(".json")) {
+        results.push(nextPath);
+      }
+    }
+  }
+  return results;
+}
+
+export async function loadRecentRuntimeReflections(params?: {
+  nowMs?: number;
+  windowMs?: number;
+  surfaces?: RuntimeReflectionSurface[];
+  limit?: number;
+}): Promise<RuntimeReflectionArtifact[]> {
+  const nowMs = params?.nowMs ?? Date.now();
+  const windowMs = Math.max(1, params?.windowMs ?? 24 * 60 * 60_000);
+  const limit = Math.max(1, params?.limit ?? 50);
+  const surfaceFilter = params?.surfaces?.length ? new Set(params.surfaces) : null;
+  const root = resolveRuntimeReflectionsRoot();
+  const files = await walkJsonFiles(root);
+  const artifacts: RuntimeReflectionArtifact[] = [];
+  for (const filePath of files) {
+    const raw = await fs.readFile(filePath, "utf8").catch(() => null);
+    if (!raw) {
+      continue;
+    }
+    const record = parseReflectionRecord(raw, filePath);
+    if (!record) {
+      continue;
+    }
+    if (surfaceFilter && !surfaceFilter.has(record.surface)) {
+      continue;
+    }
+    const createdAtMs = Date.parse(record.createdAt);
+    if (!Number.isFinite(createdAtMs) || nowMs - createdAtMs > windowMs) {
+      continue;
+    }
+    artifacts.push({ path: filePath, record });
+  }
+  return artifacts
+    .toSorted((a, b) => {
+      const bMs = Date.parse(b.record.createdAt);
+      const aMs = Date.parse(a.record.createdAt);
+      if (bMs !== aMs) {
+        return bMs - aMs;
+      }
+      return a.record.id.localeCompare(b.record.id);
+    })
+    .slice(0, limit);
+}

--- a/src/agents/startup-advisory.test.ts
+++ b/src/agents/startup-advisory.test.ts
@@ -1,0 +1,885 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const execFileUtf8Mock = vi.hoisted(() => vi.fn());
+const readFileMock = vi.hoisted(() => vi.fn());
+const writeFileMock = vi.hoisted(() => vi.fn());
+const mkdirMock = vi.hoisted(() => vi.fn());
+const writeRuntimeReflectionMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../daemon/exec-file.js", () => ({
+  execFileUtf8: execFileUtf8Mock,
+}));
+
+vi.mock("node:fs/promises", () => ({
+  readFile: readFileMock,
+  writeFile: writeFileMock,
+  mkdir: mkdirMock,
+}));
+
+vi.mock("./runtime-reflection.js", () => ({
+  writeRuntimeReflection: writeRuntimeReflectionMock,
+}));
+
+import {
+  applyStartupAutoAttachPolicy,
+  buildStartupContextAdvisory,
+  classifyStartupTaskShape,
+  fetchStartupContextRecommendations,
+  resetStartupAdvisoryBackgroundRefreshesForTest,
+  resolveStartupTaskText,
+  resolveStartupRouteContract,
+} from "./startup-advisory.js";
+
+beforeEach(() => {
+  execFileUtf8Mock.mockReset();
+  readFileMock.mockReset();
+  writeFileMock.mockReset();
+  mkdirMock.mockReset();
+  mkdirMock.mockResolvedValue(undefined);
+  writeFileMock.mockResolvedValue(undefined);
+  writeRuntimeReflectionMock.mockReset();
+  writeRuntimeReflectionMock.mockResolvedValue({
+    path: "/tmp/runtime-reflection.json",
+    record: {
+      version: 1,
+      id: "runtime-reflection",
+      surface: "startup_advisory",
+      entityId: "test",
+      claimedOutcome: "ok",
+      observedOutcome: "ok",
+      sourceRefs: [],
+      benchmarkTags: [],
+      operatorActionable: "test",
+      createdAt: "2026-03-24T00:00:00.000Z",
+    },
+  });
+  resetStartupAdvisoryBackgroundRefreshesForTest();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  resetStartupAdvisoryBackgroundRefreshesForTest();
+});
+
+describe("classifyStartupTaskShape", () => {
+  it("upgrades failed direct source reads into source discovery", () => {
+    expect(
+      classifyStartupTaskShape(
+        "read-github returned 404 for the guessed gstack repo, find the original GitHub link",
+      ),
+    ).toBe("source_discovery");
+  });
+
+  it("detects debug/runtime tasks", () => {
+    expect(classifyStartupTaskShape("Debug the cron router after a failing run")).toBe(
+      "debug_runtime",
+    );
+  });
+
+  it("detects skill/routing/policy tasks", () => {
+    expect(classifyStartupTaskShape("Review skill routing policy drift in bootstrap")).toBe(
+      "skill_routing_policy",
+    );
+  });
+
+  it("does not treat ordinary skill execution requests as policy work", () => {
+    expect(classifyStartupTaskShape("Run the knowledge-archiver skill.")).toBe("general");
+  });
+
+  it("does not treat prompt file execution tasks as policy work", () => {
+    expect(
+      classifyStartupTaskShape(
+        "Read /Users/lixun/.openclaw/workspace/overnight-mini-app-builder/DAILY_PROMPT.md and follow it exactly.",
+      ),
+    ).toBe("general");
+  });
+
+  it("does not treat skill script stdout wrappers as policy work", () => {
+    expect(
+      classifyStartupTaskShape(
+        "运行这个本地脚本并原样返回它的 stdout： APEX_X_MODE=timeline_primary /opt/homebrew/bin/python3 /Users/lixun/.openclaw/skills/x-scavenger/scripts/run_miner.py",
+      ),
+    ).toBe("general");
+  });
+
+  it("detects research/long-doc tasks", () => {
+    expect(classifyStartupTaskShape("Research this PDF and summarize the report")).toBe(
+      "research_long_doc",
+    );
+  });
+
+  it("prefers research classification over governance/policy keywords when both appear", () => {
+    expect(
+      classifyStartupTaskShape(
+        "Research long documents about agent memory governance contracts and compare the reports",
+      ),
+    ).toBe("research_long_doc");
+  });
+
+  it("falls back to general for non-matching tasks", () => {
+    expect(classifyStartupTaskShape("Say hi to the team")).toBe("general");
+  });
+});
+
+describe("resolveStartupRouteContract", () => {
+  it("upgrades source discovery tasks into an ll-first fallback workflow", () => {
+    expect(resolveStartupRouteContract("source_discovery")).toEqual({
+      routeMode: "workflow",
+      skillHints: ["ll", "bb"],
+      workflowHints: [
+        'll 调研 "<goal>"',
+        "ll 网页 <url>",
+        "bb open <url> (only if low-level page inspection is still needed)",
+      ],
+      routeReason:
+        "When a direct source read fails with 404 or an unresolved repo/link guess, escalate into source discovery: use ll first for read-only discovery and only drop to bb for low-level browser inspection.",
+    });
+  });
+
+  it("keeps debug/runtime work on skill routing with debug playbook hints", () => {
+    expect(resolveStartupRouteContract("debug_runtime")).toEqual({
+      routeMode: "skill",
+      skillHints: ["runtime-debug-playbook"],
+      workflowHints: [],
+      routeReason:
+        "Debug/runtime tasks stay primarily skill-routed because diagnosis and sequencing are still judgment-heavy.",
+    });
+  });
+
+  it("keeps skill/routing/policy work on skill routing with policy skill hints", () => {
+    expect(resolveStartupRouteContract("skill_routing_policy")).toEqual({
+      routeMode: "skill",
+      skillHints: ["global-rules", "skill-health-check"],
+      workflowHints: [],
+      routeReason:
+        "Routing and policy tasks should stay on model-routed skills unless they harden into a stable artifact workflow.",
+    });
+  });
+
+  it("marks long-doc research as hybrid with an explicit retrieval command hint", () => {
+    expect(resolveStartupRouteContract("research_long_doc")).toEqual({
+      routeMode: "hybrid",
+      skillHints: [],
+      workflowHints: ["/context recommend <task>"],
+      routeReason:
+        "Long-doc research benefits from soft skill routing plus an explicit retrieval workflow for repeatable evidence gathering.",
+    });
+  });
+});
+
+describe("resolveStartupTaskText", () => {
+  it("uses the entrypoint source hint when startup task text is provided", () => {
+    expect(
+      resolveStartupTaskText({
+        startupTaskText: "Summarize the latest webhook payload",
+        startupTaskTextSourceHint: "webhook",
+        prompt: "ignored fallback prompt",
+      }),
+    ).toEqual({
+      taskText: "Summarize the latest webhook payload",
+      source: "webhook",
+    });
+  });
+
+  it("prefers an explicit startup task hint over a rewritten fallback prompt", () => {
+    expect(
+      resolveStartupTaskText({
+        startupTaskText: "Find the original GitHub repo after read-github returned 404.",
+        prompt: "Continue where you left off. The previous model attempt failed or timed out.",
+      }),
+    ).toEqual({
+      taskText: "Find the original GitHub repo after read-github returned 404.",
+      source: "prompt",
+    });
+  });
+
+  it("falls back to history when prompt text is empty", () => {
+    expect(
+      resolveStartupTaskText({
+        prompt: "   ",
+        historyMessages: [
+          { role: "assistant", content: "done" },
+          { role: "user", content: "Debug the runtime router from yesterday's incident." },
+        ],
+      }),
+    ).toEqual({
+      taskText: "Debug the runtime router from yesterday's incident.",
+      source: "history",
+    });
+  });
+
+  it("uses extra system prompt when prompt and history are empty", () => {
+    expect(
+      resolveStartupTaskText({
+        prompt: "",
+        extraSystemPrompt: "Review the routing contract drift in bootstrap.",
+      }),
+    ).toEqual({
+      taskText: "Review the routing contract drift in bootstrap.",
+      source: "extra_system_prompt",
+    });
+  });
+});
+
+describe("fetchStartupContextRecommendations", () => {
+  it("retries python shebang scripts with an explicit interpreter when the direct exec fails", async () => {
+    readFileMock.mockResolvedValueOnce("#!/usr/bin/env python3\nprint('ok')\n");
+    execFileUtf8Mock
+      .mockResolvedValueOnce({
+        code: 1,
+        stdout: "",
+        stderr: "",
+      })
+      .mockResolvedValueOnce({
+        code: 0,
+        stdout: JSON.stringify({
+          corpus: "openclaw-internal-knowledge",
+          task: "debug cron routing",
+          generatedAt: "2026-03-19T10:00:00Z",
+          indexVersion: "test-version",
+          recommendedFiles: [],
+        }),
+        stderr: "",
+      });
+
+    const payload = await fetchStartupContextRecommendations("debug cron routing", {
+      binPath: "/tmp/recommend-startup-context",
+      timeoutMs: 1234,
+    });
+
+    expect(execFileUtf8Mock).toHaveBeenNthCalledWith(
+      1,
+      "/tmp/recommend-startup-context",
+      ["--task", "debug cron routing", "--limit-files", "3", "--sections-per-file", "2"],
+      { timeout: 1234 },
+    );
+    expect(execFileUtf8Mock).toHaveBeenNthCalledWith(
+      2,
+      "/opt/homebrew/bin/python3",
+      [
+        "/tmp/recommend-startup-context",
+        "--task",
+        "debug cron routing",
+        "--limit-files",
+        "3",
+        "--sections-per-file",
+        "2",
+      ],
+      { timeout: 1234 },
+    );
+    expect(payload.indexVersion).toBe("test-version");
+  });
+
+  it("calls the shared recommend script with a timeout and parses the payload", async () => {
+    execFileUtf8Mock.mockResolvedValueOnce({
+      code: 0,
+      stdout: JSON.stringify({
+        corpus: "openclaw-internal-knowledge",
+        task: "debug cron routing",
+        generatedAt: "2026-03-19T10:00:00Z",
+        indexVersion: "test-version",
+        recommendedFiles: [
+          {
+            rank: 1,
+            path: "/tmp/cron-runbook.md",
+            sourceType: "runbook",
+            title: "Cron Runbook",
+            rationale: "Top runbook match after mandatory reads.",
+            sections: [
+              {
+                section: "Cron > Router",
+                excerpt: "Investigate the router script first.",
+                score: 12.5,
+              },
+            ],
+          },
+        ],
+      }),
+      stderr: "",
+    });
+
+    const payload = await fetchStartupContextRecommendations("debug cron routing", {
+      binPath: "/tmp/recommend-startup-context",
+      limitFiles: 2,
+      sectionsPerFile: 1,
+      timeoutMs: 1234,
+    });
+
+    expect(execFileUtf8Mock).toHaveBeenCalledWith(
+      "/tmp/recommend-startup-context",
+      ["--task", "debug cron routing", "--limit-files", "2", "--sections-per-file", "1"],
+      { timeout: 1234 },
+    );
+    expect(payload.recommendedFiles[0]?.path).toBe("/tmp/cron-runbook.md");
+  });
+});
+
+describe("buildStartupContextAdvisory", () => {
+  it("returns a not_applicable stub when no task text is available", async () => {
+    await expect(buildStartupContextAdvisory(undefined)).resolves.toEqual({
+      mode: "advisory",
+      source: "pageindex-startup-context",
+      status: "not_applicable",
+      taskShape: "general",
+      routeMode: "skill",
+      skillHints: [],
+      workflowHints: [],
+      routeReason:
+        "General startup keeps the default skill-routed path unless a repeatable operator workflow clearly fits better.",
+      note: "No task text available for this session.",
+      recommendationCount: 0,
+      recommendedFiles: [],
+    });
+    expect(writeRuntimeReflectionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        surface: "startup_advisory",
+        claimedOutcome: "startup_advisory_requested",
+        observedOutcome: "task_text_missing",
+      }),
+    );
+  });
+});
+
+describe("buildStartupContextAdvisory", () => {
+  it("writes a cache artifact after the first successful advisory", async () => {
+    vi.stubEnv("OPENCLAW_STATE_DIR", "/tmp/openclaw-state");
+    readFileMock.mockRejectedValueOnce(new Error("ENOENT"));
+    execFileUtf8Mock.mockResolvedValueOnce({
+      code: 0,
+      stdout: JSON.stringify({
+        corpus: "openclaw-internal-knowledge",
+        task: "Debug the cron router",
+        generatedAt: "2026-03-20T10:00:00Z",
+        indexVersion: "fresh-version",
+        recommendedFiles: [
+          {
+            rank: 1,
+            path: "/tmp/docs/runbooks/cron-runbook.md",
+            sourceType: "docs",
+            title: "Cron Runbook",
+            rationale: "Top docs match.",
+            sections: [
+              {
+                section: "Cron Runbook",
+                excerpt: "Start with the runbook.",
+                score: 25,
+              },
+            ],
+          },
+        ],
+      }),
+      stderr: "",
+    });
+
+    const advisory = await buildStartupContextAdvisory("Debug the cron router");
+
+    expect(advisory?.source).toBe("pageindex-startup-context");
+    expect(writeFileMock).toHaveBeenCalledTimes(1);
+    expect(writeFileMock.mock.calls[0]?.[0]).toBe(
+      "/tmp/openclaw-state/memory/last_advisory_cache.json",
+    );
+    const persisted = JSON.parse(String(writeFileMock.mock.calls[0]?.[1] ?? "{}"));
+    expect(persisted.advisory?.source).toBe("pageindex-startup-context");
+    expect(persisted.advisory?.taskShape).toBe("debug_runtime");
+  });
+
+  it("returns a cached advisory immediately and refreshes it in the background", async () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.stubEnv("OPENCLAW_STATE_DIR", "/tmp/openclaw-state");
+    readFileMock.mockResolvedValueOnce(
+      JSON.stringify({
+        version: 1,
+        cachedAt: "2026-03-20T10:00:00Z",
+        taskShape: "debug_runtime",
+        taskPreview: "Debug the cron router",
+        advisory: {
+          mode: "advisory",
+          source: "pageindex-startup-context",
+          status: "ready",
+          taskShape: "debug_runtime",
+          routeMode: "skill",
+          skillHints: ["runtime-debug-playbook"],
+          workflowHints: [],
+          routeReason:
+            "Debug/runtime tasks stay primarily skill-routed because diagnosis and sequencing are still judgment-heavy.",
+          note: "Advisory only. Review these after mandatory reads; nothing was auto-injected into the prompt.",
+          recommendationCount: 1,
+          generatedAt: "2026-03-20T10:00:00Z",
+          indexVersion: "cached-version",
+          recommendedFiles: [
+            {
+              rank: 1,
+              path: "/tmp/docs/runbooks/cron-runbook.md",
+              sourceType: "docs",
+              title: "Cron Runbook",
+              rationale: "Top docs match.",
+              sections: [
+                {
+                  section: "Cron Runbook",
+                  excerpt: "Start with the runbook.",
+                  score: 25,
+                },
+              ],
+            },
+          ],
+          autoAttachStatus: "not_eligible",
+          autoAttachNote: "Advisory generated, but auto-attach policy has not been evaluated yet.",
+          autoAttachedFiles: [],
+        },
+      }),
+    );
+    execFileUtf8Mock.mockResolvedValueOnce({
+      code: 0,
+      stdout: JSON.stringify({
+        corpus: "openclaw-internal-knowledge",
+        task: "Debug the cron router",
+        generatedAt: "2026-03-20T11:00:00Z",
+        indexVersion: "fresh-version",
+        recommendedFiles: [
+          {
+            rank: 1,
+            path: "/tmp/docs/runbooks/cron-runbook-v2.md",
+            sourceType: "docs",
+            title: "Cron Runbook v2",
+            rationale: "New top docs match.",
+            sections: [
+              {
+                section: "Cron Runbook v2",
+                excerpt: "Use the refreshed runbook.",
+                score: 26,
+              },
+            ],
+          },
+        ],
+      }),
+      stderr: "",
+    });
+
+    const advisory = await buildStartupContextAdvisory("Debug the cron router");
+
+    expect(advisory?.source).toBe("cached");
+    expect(advisory?.note).toBe("Using cached advisory, refreshing in background.");
+    expect(advisory?.autoAttachStatus).toBe("not_eligible");
+    expect(writeRuntimeReflectionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        surface: "startup_advisory",
+        claimedOutcome: "fresh_advisory",
+        observedOutcome: "cached_advisory",
+      }),
+    );
+    await vi.waitFor(() => expect(writeFileMock).toHaveBeenCalledTimes(1));
+    expect(logSpy).toHaveBeenCalledWith("[startup-advisory] 后台刷新缓存完成");
+    const persisted = JSON.parse(String(writeFileMock.mock.calls[0]?.[1] ?? "{}"));
+    expect(persisted.advisory?.indexVersion).toBe("fresh-version");
+    logSpy.mockRestore();
+  });
+
+  it("returns a first-run indexing note after the uncached fetch times out and refreshes the cache later", async () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.stubEnv("OPENCLAW_STATE_DIR", "/tmp/openclaw-state");
+    readFileMock.mockRejectedValueOnce(new Error("ENOENT"));
+    readFileMock.mockRejectedValueOnce(new Error("not a python script"));
+    execFileUtf8Mock
+      .mockResolvedValueOnce({
+        code: 1,
+        stdout: "",
+        stderr: "Command timed out after 15000ms",
+      })
+      .mockResolvedValueOnce({
+        code: 0,
+        stdout: JSON.stringify({
+          corpus: "openclaw-internal-knowledge",
+          task: "Debug the cron router",
+          generatedAt: "2026-03-20T11:00:00Z",
+          indexVersion: "refreshed-version",
+          recommendedFiles: [],
+        }),
+        stderr: "",
+      });
+
+    const advisory = await buildStartupContextAdvisory("Debug the cron router");
+
+    expect(advisory?.status).toBe("unavailable");
+    expect(advisory?.note).toBe("首次启动索引中，下次将秒级生效");
+    expect(execFileUtf8Mock).toHaveBeenNthCalledWith(
+      1,
+      expect.any(String),
+      expect.any(Array),
+      { timeout: 15_000 },
+    );
+    await vi.waitFor(() =>
+      expect(execFileUtf8Mock).toHaveBeenNthCalledWith(
+        2,
+        expect.any(String),
+        expect.any(Array),
+        { timeout: 30_000 },
+      ),
+    );
+    await vi.waitFor(() => expect(writeFileMock).toHaveBeenCalledTimes(1));
+    expect(logSpy).toHaveBeenCalledWith("[startup-advisory] 后台刷新缓存完成");
+    logSpy.mockRestore();
+  });
+
+  it("logs a warning when the background refresh fails and keeps the previous cache", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.stubEnv("OPENCLAW_STATE_DIR", "/tmp/openclaw-state");
+    readFileMock.mockResolvedValueOnce(
+      JSON.stringify({
+        version: 1,
+        cachedAt: "2026-03-20T10:00:00Z",
+        taskShape: "debug_runtime",
+        advisory: {
+          mode: "advisory",
+          source: "pageindex-startup-context",
+          status: "ready",
+          taskShape: "debug_runtime",
+          routeMode: "skill",
+          skillHints: ["runtime-debug-playbook"],
+          workflowHints: [],
+          routeReason:
+            "Debug/runtime tasks stay primarily skill-routed because diagnosis and sequencing are still judgment-heavy.",
+          note: "Advisory only.",
+          recommendationCount: 0,
+          recommendedFiles: [],
+          autoAttachStatus: "not_eligible",
+          autoAttachNote: "Advisory generated, but auto-attach policy has not been evaluated yet.",
+          autoAttachedFiles: [],
+        },
+      }),
+    );
+    execFileUtf8Mock.mockResolvedValueOnce({
+      code: 1,
+      stdout: "",
+      stderr: "boom",
+    });
+
+    const advisory = await buildStartupContextAdvisory("Debug the cron router");
+
+    expect(advisory?.source).toBe("cached");
+    await vi.waitFor(() =>
+      expect(warnSpy).toHaveBeenCalledWith(
+        "[startup-advisory] 后台刷新失败，保留旧缓存:",
+        expect.any(Error),
+      ),
+    );
+    expect(writeFileMock).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it("returns not_applicable for general tasks", async () => {
+    const advisory = await buildStartupContextAdvisory("Say hi to the team");
+
+    expect(advisory?.status).toBe("not_applicable");
+    expect(advisory?.taskShape).toBe("general");
+    expect(advisory?.routeMode).toBe("skill");
+    expect(advisory?.recommendationCount).toBe(0);
+  });
+
+  it("short-circuits source discovery tasks to not_applicable without calling PageIndex", async () => {
+    execFileUtf8Mock.mockClear();
+    const advisory = await buildStartupContextAdvisory(
+      "read-github returned 404 for the guessed repo slug, find the authoritative source link",
+    );
+
+    expect(execFileUtf8Mock).not.toHaveBeenCalled();
+    expect(advisory?.status).toBe("not_applicable");
+    expect(advisory?.taskShape).toBe("source_discovery");
+    expect(advisory?.routeMode).toBe("workflow");
+    expect(advisory?.skillHints).toEqual(["ll", "bb"]);
+    expect(advisory?.recommendationCount).toBe(0);
+    expect(advisory?.autoAttachStatus).toBe("not_eligible");
+    expect(advisory?.autoAttachNote).toBe(
+      "Auto-attach does not run for source discovery. Keep source lookup lightweight and operator-visible.",
+    );
+    expect(writeRuntimeReflectionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        surface: "startup_advisory",
+        claimedOutcome: "startup_advisory_requested",
+        observedOutcome: "classifier_short_circuit_source_discovery",
+      }),
+    );
+  });
+
+  it("degrades to unavailable when recommendation fails", async () => {
+    execFileUtf8Mock.mockResolvedValueOnce({
+      code: 1,
+      stdout: "",
+      stderr: "boom",
+    });
+
+    const advisory = await buildStartupContextAdvisory("Debug the cron router");
+
+    expect(advisory?.status).toBe("unavailable");
+    expect(advisory?.taskShape).toBe("debug_runtime");
+    expect(advisory?.routeMode).toBe("skill");
+    expect(advisory?.skillHints).toEqual(["runtime-debug-playbook"]);
+    expect(advisory?.autoAttachNote).toBe(
+      "Auto-attach did not run because startup advisory was unavailable.",
+    );
+    expect(advisory?.error).toContain("boom");
+    expect(writeRuntimeReflectionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        surface: "startup_advisory",
+        claimedOutcome: "fresh_advisory",
+        observedOutcome: "advisory_unavailable",
+      }),
+    );
+  });
+
+  it("preserves unavailable auto-attach note through the auto-attach policy stage", async () => {
+    const result = await applyStartupAutoAttachPolicy({
+      advisory: {
+        mode: "advisory",
+        source: "pageindex-startup-context",
+        status: "unavailable",
+        taskShape: "debug_runtime",
+        routeMode: "skill",
+        skillHints: ["runtime-debug-playbook"],
+        workflowHints: [],
+        routeReason:
+          "Debug/runtime tasks stay primarily skill-routed because diagnosis and sequencing are still judgment-heavy.",
+        note: "Startup advisory was attempted but unavailable. Bootstrap stayed unchanged.",
+        recommendationCount: 0,
+        recommendedFiles: [],
+        autoAttachStatus: "not_eligible",
+        autoAttachNote: "Auto-attach did not run because startup advisory was unavailable.",
+        autoAttachedFiles: [],
+        error: "boom",
+      },
+      bootstrapFiles: [],
+      contextFiles: [],
+      bootstrapMaxChars: 20_000,
+      bootstrapTotalMaxChars: 150_000,
+    });
+
+    expect(result.advisory?.autoAttachStatus).toBe("not_eligible");
+    expect(result.advisory?.autoAttachNote).toBe(
+      "Auto-attach did not run because startup advisory was unavailable.",
+    );
+  });
+});
+
+describe("applyStartupAutoAttachPolicy", () => {
+  it("attaches one eligible debug/runtime file into prompt context", async () => {
+    readFileMock.mockResolvedValueOnce("# Cron Runbook\n\nUse the artifact-first rule.");
+
+    const result = await applyStartupAutoAttachPolicy({
+      advisory: {
+        mode: "advisory",
+        source: "pageindex-startup-context",
+        status: "ready",
+        taskShape: "debug_runtime",
+        routeMode: "skill",
+        skillHints: ["runtime-debug-playbook"],
+        workflowHints: [],
+        routeReason:
+          "Debug/runtime tasks stay primarily skill-routed because diagnosis and sequencing are still judgment-heavy.",
+        note: "Advisory only.",
+        recommendationCount: 1,
+        recommendedFiles: [
+          {
+            rank: 1,
+            path: "/tmp/docs/runbooks/cron-runbook.md",
+            sourceType: "docs",
+            title: "Cron Runbook",
+            rationale: "Top docs match.",
+            sections: [
+              {
+                section: "Cron Runbook",
+                excerpt: "# Cron Runbook",
+                score: 22,
+              },
+            ],
+          },
+        ],
+      },
+      bootstrapFiles: [],
+      contextFiles: [],
+      bootstrapMaxChars: 20_000,
+      bootstrapTotalMaxChars: 150_000,
+    });
+
+    expect(result.advisory?.autoAttachStatus).toBe("applied");
+    expect(result.advisory?.autoAttachedFiles).toEqual(["/tmp/docs/runbooks/cron-runbook.md"]);
+    expect(result.contextFiles.some((file) => file.path === "/tmp/docs/runbooks/cron-runbook.md")).toBe(
+      true,
+    );
+  });
+
+  it("skips when the best recommendation does not meet the attach policy", async () => {
+    const result = await applyStartupAutoAttachPolicy({
+      advisory: {
+        mode: "advisory",
+        source: "pageindex-startup-context",
+        status: "ready",
+        taskShape: "debug_runtime",
+        routeMode: "skill",
+        skillHints: ["runtime-debug-playbook"],
+        workflowHints: [],
+        routeReason:
+          "Debug/runtime tasks stay primarily skill-routed because diagnosis and sequencing are still judgment-heavy.",
+        note: "Advisory only.",
+        recommendationCount: 1,
+        recommendedFiles: [
+          {
+            rank: 1,
+            path: "/tmp/docs/context/skill-routing-notes.md",
+            sourceType: "docs",
+            title: "Skill Routing Notes",
+            rationale: "Top docs match.",
+            sections: [
+              {
+                section: "Skill Routing Notes",
+                excerpt: "Debug notes",
+                score: 12,
+              },
+            ],
+          },
+        ],
+      },
+      bootstrapFiles: [],
+      contextFiles: [],
+      bootstrapMaxChars: 20_000,
+      bootstrapTotalMaxChars: 150_000,
+    });
+
+    expect(result.advisory?.autoAttachStatus).toBe("skipped");
+    expect(result.contextFiles).toHaveLength(0);
+  });
+
+  it("keeps source discovery advisory visible instead of auto-attaching", async () => {
+    const result = await applyStartupAutoAttachPolicy({
+      advisory: {
+        mode: "advisory",
+        source: "pageindex-startup-context",
+        status: "ready",
+        taskShape: "source_discovery",
+        routeMode: "workflow",
+        skillHints: ["ll", "bb"],
+        workflowHints: ['ll 调研 "<goal>"', "ll 网页 <url>"],
+        routeReason:
+          "When a direct source read fails with 404 or an unresolved repo/link guess, escalate into source discovery: use ll first for read-only discovery and only drop to bb for low-level browser inspection.",
+        note: "Advisory only.",
+        recommendationCount: 1,
+        recommendedFiles: [
+          {
+            rank: 1,
+            path: "/tmp/docs/context/skill-routing-escalation.md",
+            sourceType: "docs",
+            title: "Skill Routing Escalation",
+            rationale: "Route the operator toward source discovery.",
+            sections: [
+              {
+                section: "Failure upgrade",
+                excerpt: "Escalate source read failures into discovery.",
+                score: 24,
+              },
+            ],
+          },
+        ],
+      },
+      bootstrapFiles: [],
+      contextFiles: [],
+      bootstrapMaxChars: 20_000,
+      bootstrapTotalMaxChars: 150_000,
+    });
+
+    expect(result.advisory?.autoAttachStatus).toBe("not_eligible");
+    expect(result.advisory?.autoAttachNote).toBe(
+      "Auto-attach v1 does not run for source discovery; keep the fallback lightweight and operator-visible.",
+    );
+    expect(result.contextFiles).toHaveLength(0);
+  });
+
+  it("does not auto-attach cached startup advisories", async () => {
+    const result = await applyStartupAutoAttachPolicy({
+      advisory: {
+        mode: "advisory",
+        source: "cached",
+        status: "ready",
+        taskShape: "debug_runtime",
+        routeMode: "skill",
+        skillHints: ["runtime-debug-playbook"],
+        workflowHints: [],
+        routeReason:
+          "Debug/runtime tasks stay primarily skill-routed because diagnosis and sequencing are still judgment-heavy.",
+        note: "Using cached advisory, refreshing in background.",
+        recommendationCount: 1,
+        recommendedFiles: [
+          {
+            rank: 1,
+            path: "/tmp/docs/runbooks/cron-runbook.md",
+            sourceType: "docs",
+            title: "Cron Runbook",
+            rationale: "Top docs match.",
+            sections: [
+              {
+                section: "Cron Runbook",
+                excerpt: "Use the artifact-first rule.",
+                score: 22,
+              },
+            ],
+          },
+        ],
+        autoAttachStatus: "not_eligible",
+        autoAttachNote: "Using cached advisory, refreshing in background.",
+        autoAttachedFiles: [],
+      },
+      bootstrapFiles: [],
+      contextFiles: [],
+      bootstrapMaxChars: 20_000,
+      bootstrapTotalMaxChars: 150_000,
+    });
+
+    expect(result.advisory?.autoAttachStatus).toBe("not_eligible");
+    expect(result.advisory?.autoAttachNote).toBe(
+      "Auto-attach is skipped for cached startup advisory; wait for a fresh refresh before attaching files.",
+    );
+    expect(result.contextFiles).toHaveLength(0);
+  });
+
+  it("attaches one eligible policy/context file with the stricter policy path", async () => {
+    readFileMock.mockResolvedValueOnce("# Routing Escalation\n\nRead the policy contract first.");
+
+    const result = await applyStartupAutoAttachPolicy({
+      advisory: {
+        mode: "advisory",
+        source: "pageindex-startup-context",
+        status: "ready",
+        taskShape: "skill_routing_policy",
+        routeMode: "skill",
+        skillHints: ["global-rules", "skill-health-check"],
+        workflowHints: [],
+        routeReason:
+          "Routing and policy tasks should stay on model-routed skills unless they harden into a stable artifact workflow.",
+        note: "Advisory only.",
+        recommendationCount: 1,
+        recommendedFiles: [
+          {
+            rank: 1,
+            path: "/tmp/docs/context/skill-routing-escalation.md",
+            sourceType: "docs",
+            title: "Skill Routing Escalation",
+            rationale: "Top policy docs match.",
+            sections: [
+              {
+                section: "Escalation",
+                excerpt: "Read the policy contract first.",
+                score: 24,
+              },
+            ],
+          },
+        ],
+      },
+      bootstrapFiles: [],
+      contextFiles: [],
+      bootstrapMaxChars: 20_000,
+      bootstrapTotalMaxChars: 150_000,
+    });
+
+    expect(result.advisory?.autoAttachStatus).toBe("applied");
+    expect(result.advisory?.autoAttachedFiles).toEqual([
+      "/tmp/docs/context/skill-routing-escalation.md",
+    ]);
+  });
+});

--- a/src/agents/startup-advisory.ts
+++ b/src/agents/startup-advisory.ts
@@ -1,0 +1,1287 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import path from "node:path";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import type {
+  SessionTaskTextSource,
+  SessionStartupAdvisory,
+  SessionStartupRecommendationFile,
+  SessionStartupRecommendationSection,
+} from "../config/sessions/types.js";
+import { resolveStateDir } from "../config/paths.js";
+import { execFileUtf8 } from "../daemon/exec-file.js";
+import { buildBootstrapContextFiles } from "./pi-embedded-helpers.js";
+import type { EmbeddedContextFile } from "./pi-embedded-helpers.js";
+import { writeRuntimeReflection } from "./runtime-reflection.js";
+import type { WorkspaceBootstrapFile } from "./workspace.js";
+
+const DEFAULT_RECOMMEND_BIN =
+  "/Users/lixun/.openclaw/workspace/scripts/pageindex/recommend-startup-context";
+const DEFAULT_PYTHON_BINS = ["/opt/homebrew/bin/python3", "/usr/bin/python3", "python3"];
+const DEFAULT_RECOMMEND_TIMEOUT_MS = 8_000;
+const INITIAL_UNCACHED_RECOMMEND_TIMEOUT_MS = 15_000;
+const BACKGROUND_REFRESH_TIMEOUT_MS = 30_000;
+const STARTUP_ADVISORY_CACHE_FILENAME = "last_advisory_cache.json";
+const STARTUP_ADVISORY_CACHE_VERSION = 1;
+const AUTO_ATTACH_MAX_CHARS = 6_000;
+const AUTO_ATTACH_MIN_SCORE = 18;
+const POLICY_AUTO_ATTACH_MAX_CHARS = 4_000;
+const POLICY_AUTO_ATTACH_MIN_SCORE = 20;
+const STARTUP_TASK_TEXT_MAX_CHARS = 1_200;
+const CACHED_STARTUP_ADVISORY_NOTE = "Using cached advisory, refreshing in background.";
+const CACHED_STARTUP_AUTO_ATTACH_NOTE =
+  "Auto-attach is skipped for cached startup advisory; wait for a fresh refresh before attaching files.";
+const INITIAL_INDEXING_NOTE = "首次启动索引中，下次将秒级生效";
+
+type StartupAdvisoryCacheEntry = {
+  version: number;
+  cachedAt: string;
+  taskShape: SessionStartupAdvisory["taskShape"];
+  taskPreview?: string;
+  advisory: SessionStartupAdvisory;
+};
+
+const startupAdvisoryBackgroundRefreshes = new Map<string, Promise<void>>();
+
+export function resetStartupAdvisoryBackgroundRefreshesForTest(): void {
+  startupAdvisoryBackgroundRefreshes.clear();
+}
+
+export type StartupContextRecommendationPayload = {
+  corpus: string;
+  task: string;
+  generatedAt: string;
+  indexVersion: string;
+  recommendedFiles: SessionStartupRecommendationFile[];
+};
+
+export type StartupRouteContract = {
+  routeMode: "skill" | "workflow" | "hybrid";
+  skillHints: string[];
+  workflowHints: string[];
+  routeReason: string;
+};
+
+export type StartupTaskTextResolution = {
+  taskText: string | undefined;
+  source: SessionTaskTextSource;
+};
+
+type StartupReflectionContext = {
+  sessionKey?: string;
+  taskTextSource?: SessionTaskTextSource;
+};
+
+function resolveStartupAdvisoryCachePath(): string {
+  return path.join(resolveStateDir(), "memory", STARTUP_ADVISORY_CACHE_FILENAME);
+}
+
+function supportsStartupAdvisoryCache(taskShape: SessionStartupAdvisory["taskShape"]): boolean {
+  return taskShape !== "general" && taskShape !== "source_discovery";
+}
+
+function isTimeoutLikeStartupError(errorMessage: string | undefined): boolean {
+  return /timed out|timeout|etimedout|sigterm|killed/i.test(errorMessage ?? "");
+}
+
+function emitStartupAdvisoryReflection(params: {
+  taskText?: string;
+  taskShape: SessionStartupAdvisory["taskShape"];
+  sessionKey?: string;
+  taskTextSource?: SessionTaskTextSource;
+  claimedOutcome: string;
+  observedOutcome: string;
+  claimMismatch?: boolean;
+  recoveryKind?: string;
+  route?: StartupRouteContract;
+  advisory?: SessionStartupAdvisory;
+  operatorActionable: string;
+  sourceRefs?: string[];
+  metadata?: Record<string, unknown>;
+}): void {
+  const taskPreview = normalizeTaskTextCandidate(params.taskText);
+  const entityId = taskPreview ?? params.sessionKey ?? params.taskShape;
+  void writeRuntimeReflection({
+    surface: "startup_advisory",
+    entityId,
+    sessionKey: params.sessionKey,
+    taskShape: params.taskShape,
+    claimedOutcome: params.claimedOutcome,
+    observedOutcome: params.observedOutcome,
+    claimMismatch: params.claimMismatch,
+    recoveryKind: params.recoveryKind,
+    sourceRefs: [
+      ...(params.sourceRefs ?? []),
+      params.sessionKey ? `session:${params.sessionKey}` : "",
+      params.taskTextSource ? `task-text-source:${params.taskTextSource}` : "",
+    ].filter(Boolean),
+    benchmarkTags: ["startup-advisory", "honest-outcome"],
+    operatorActionable: params.operatorActionable,
+    metadata: {
+      taskPreview,
+      taskTextSource: params.taskTextSource,
+      routeMode: params.route?.routeMode ?? params.advisory?.routeMode,
+      autoAttachStatus: params.advisory?.autoAttachStatus,
+      advisorySource: params.advisory?.source,
+      advisoryStatus: params.advisory?.status,
+      ...params.metadata,
+    },
+  }).catch(() => {});
+}
+
+function buildUnavailableStartupAdvisory(params: {
+  taskShape: SessionStartupAdvisory["taskShape"];
+  route: StartupRouteContract;
+  note: string;
+  error: string;
+  autoAttachNote?: string;
+}): SessionStartupAdvisory {
+  return {
+    mode: "advisory",
+    source: "pageindex-startup-context",
+    status: "unavailable",
+    taskShape: params.taskShape,
+    ...params.route,
+    note: params.note,
+    recommendationCount: 0,
+    recommendedFiles: [],
+    autoAttachStatus: "not_eligible",
+    autoAttachNote:
+      params.autoAttachNote ??
+      "Auto-attach did not run because startup advisory was unavailable.",
+    autoAttachedFiles: [],
+    error: params.error,
+  };
+}
+
+function validateStartupAdvisoryCacheEntry(
+  value: unknown,
+): asserts value is StartupAdvisoryCacheEntry {
+  if (!value || typeof value !== "object") {
+    throw new Error("Invalid startup advisory cache: entry must be an object");
+  }
+  const record = value as Record<string, unknown>;
+  if (
+    typeof record.version !== "number" ||
+    typeof record.cachedAt !== "string" ||
+    typeof record.taskShape !== "string" ||
+    !record.advisory ||
+    typeof record.advisory !== "object"
+  ) {
+    throw new Error("Invalid startup advisory cache: missing metadata");
+  }
+  const advisory = record.advisory as Record<string, unknown>;
+  if (
+    advisory.mode !== "advisory" ||
+    typeof advisory.source !== "string" ||
+    typeof advisory.status !== "string" ||
+    typeof advisory.taskShape !== "string" ||
+    !Array.isArray(advisory.recommendedFiles)
+  ) {
+    throw new Error("Invalid startup advisory cache: malformed advisory");
+  }
+}
+
+async function readStartupAdvisoryCache(
+  taskShape: SessionStartupAdvisory["taskShape"],
+): Promise<StartupAdvisoryCacheEntry | undefined> {
+  if (!supportsStartupAdvisoryCache(taskShape)) {
+    return undefined;
+  }
+  try {
+    const raw = await readFile(resolveStartupAdvisoryCachePath(), "utf8");
+    const parsed: unknown = JSON.parse(raw);
+    validateStartupAdvisoryCacheEntry(parsed);
+    if (parsed.version !== STARTUP_ADVISORY_CACHE_VERSION) {
+      return undefined;
+    }
+    if (parsed.taskShape !== taskShape) {
+      return undefined;
+    }
+    if (parsed.advisory.status !== "ready") {
+      return undefined;
+    }
+    return parsed;
+  } catch {
+    return undefined;
+  }
+}
+
+function toCachedStartupAdvisory(
+  entry: StartupAdvisoryCacheEntry,
+): SessionStartupAdvisory {
+  return {
+    ...entry.advisory,
+    source: "cached",
+    note: CACHED_STARTUP_ADVISORY_NOTE,
+    autoAttachStatus: "not_eligible",
+    autoAttachNote: CACHED_STARTUP_AUTO_ATTACH_NOTE,
+    autoAttachedFiles: [],
+  };
+}
+
+async function persistStartupAdvisoryCache(params: {
+  task: string;
+  advisory: SessionStartupAdvisory;
+}): Promise<void> {
+  if (!supportsStartupAdvisoryCache(params.advisory.taskShape)) {
+    return;
+  }
+  if (params.advisory.status !== "ready") {
+    return;
+  }
+  const advisoryToPersist: SessionStartupAdvisory = {
+    ...params.advisory,
+    source: "pageindex-startup-context",
+  };
+  const cachePath = resolveStartupAdvisoryCachePath();
+  const payload: StartupAdvisoryCacheEntry = {
+    version: STARTUP_ADVISORY_CACHE_VERSION,
+    cachedAt: new Date().toISOString(),
+    taskShape: advisoryToPersist.taskShape,
+    taskPreview: normalizeTaskTextCandidate(params.task),
+    advisory: advisoryToPersist,
+  };
+  await mkdir(path.dirname(cachePath), { recursive: true });
+  await writeFile(cachePath, JSON.stringify(payload, null, 2) + "\n", "utf8");
+}
+
+async function resolvePythonFallbackInvocation(
+  binPath: string,
+  args: string[],
+): Promise<{ command: string; args: string[] } | undefined> {
+  let header = "";
+  try {
+    header = (await readFile(binPath, "utf8")).slice(0, 256);
+  } catch {
+    return undefined;
+  }
+  const firstLine = header.split(/\r?\n/, 1)[0]?.trim() ?? "";
+  if (!firstLine.startsWith("#!")) {
+    return undefined;
+  }
+  if (!/python3?/.test(firstLine)) {
+    return undefined;
+  }
+  const override = process.env.OPENCLAW_RECOMMEND_STARTUP_CONTEXT_PYTHON?.trim();
+  const pythonBin = override || DEFAULT_PYTHON_BINS[0];
+  return {
+    command: pythonBin,
+    args: [binPath, ...args],
+  };
+}
+
+function normalizeTaskTextCandidate(value: string | undefined): string | undefined {
+  const normalized = value?.replace(/\s+/g, " ").trim();
+  if (!normalized) {
+    return undefined;
+  }
+  if (normalized.length <= STARTUP_TASK_TEXT_MAX_CHARS) {
+    return normalized;
+  }
+  return `${normalized.slice(0, STARTUP_TASK_TEXT_MAX_CHARS - 1).trimEnd()}…`;
+}
+
+function extractLatestUserMessageText(messages: AgentMessage[] | undefined): string | undefined {
+  if (!messages?.length) {
+    return undefined;
+  }
+
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    const message = messages[i];
+    if (!message || message.role !== "user") {
+      continue;
+    }
+    if (typeof message.content === "string") {
+      const normalized = normalizeTaskTextCandidate(message.content);
+      if (normalized) {
+        return normalized;
+      }
+      continue;
+    }
+    if (!Array.isArray(message.content)) {
+      continue;
+    }
+    const text = message.content
+      .map((block) => {
+        if (!block || typeof block !== "object") {
+          return "";
+        }
+        const typedBlock = block as { text?: unknown };
+        return typeof typedBlock.text === "string" ? typedBlock.text : "";
+      })
+      .filter(Boolean)
+      .join(" ")
+      .trim();
+    const normalized = normalizeTaskTextCandidate(text);
+    if (normalized) {
+      return normalized;
+    }
+  }
+
+  return undefined;
+}
+
+export function resolveStartupTaskText(params: {
+  startupTaskText?: string;
+  startupTaskTextSourceHint?: SessionTaskTextSource;
+  prompt?: string;
+  historyMessages?: AgentMessage[];
+  extraSystemPrompt?: string;
+}): StartupTaskTextResolution {
+  const hintedTaskText = normalizeTaskTextCandidate(params.startupTaskText);
+  if (hintedTaskText) {
+    return { taskText: hintedTaskText, source: params.startupTaskTextSourceHint ?? "prompt" };
+  }
+
+  const promptText = normalizeTaskTextCandidate(params.prompt);
+  if (promptText) {
+    return { taskText: promptText, source: "prompt" };
+  }
+
+  const historyText = extractLatestUserMessageText(params.historyMessages);
+  if (historyText) {
+    return { taskText: historyText, source: "history" };
+  }
+
+  const extraPromptText = normalizeTaskTextCandidate(params.extraSystemPrompt);
+  if (extraPromptText) {
+    return { taskText: extraPromptText, source: "extra_system_prompt" };
+  }
+  return { taskText: undefined, source: "none" };
+}
+
+function isSourceDiscoveryTask(normalized: string): boolean {
+  if (!normalized) {
+    return false;
+  }
+
+  if (
+    /(read-github|read github|direct source read|source discovery|source unresolved|repo slug|github 404|原始信源|原始链接|仓库名不是|仓库地址不确定)/i.test(
+      normalized,
+    )
+  ) {
+    return true;
+  }
+
+  const sourceContext =
+    /(github|repo|repository|slug|source|original link|source link|url|x\.com|tweet|tweet thread|网页|页面|链接|原帖|原文|原始链接|原始信源|仓库|仓库名|仓库地址|github 链接|源地址)/i.test(
+      normalized,
+    );
+  const failureSignal =
+    /(404|not found|missing|unresolved|can't find|cannot find|couldn't find|failed|failure|guess|guessed|uncertain|unknown|找不到|未确认|不确定|猜的|不存在|读取失败|直读失败|没找到)/i.test(
+      normalized,
+    );
+
+  return sourceContext && failureSignal;
+}
+
+function isSkillRoutingPolicyTask(normalized: string): boolean {
+  if (!normalized) {
+    return false;
+  }
+
+  if (
+    /(skill routing|routing policy|route contract|route rules?|policy drift|bootstrap contract|startup advisory|startup context|context policy|system prompt|prompt contract|global-rules|skill-health-check|memory governance|governance contract|agents\.md|claude\.md)/i.test(
+      normalized,
+    )
+  ) {
+    return true;
+  }
+
+  if (
+    /\bskill\b/i.test(normalized) &&
+    /\b(route|routing|policy|governance|context|startup|bootstrap|health|contract)\b/i.test(
+      normalized,
+    )
+  ) {
+    return true;
+  }
+
+  if (
+    /(技能路由|路由策略|策略漂移|启动建议|启动上下文|上下文策略|系统提示词|提示词契约|全局规则|技能健康检查|记忆治理|治理契约|agents\.md|claude\.md)/i.test(
+      normalized,
+    )
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+function validateRecommendationSection(
+  value: unknown,
+): asserts value is SessionStartupRecommendationSection {
+  if (
+    !value ||
+    typeof value !== "object" ||
+    typeof (value as Record<string, unknown>).section !== "string" ||
+    typeof (value as Record<string, unknown>).excerpt !== "string" ||
+    typeof (value as Record<string, unknown>).score !== "number"
+  ) {
+    throw new Error("Invalid recommend-startup payload: malformed section entry");
+  }
+}
+
+function validateRecommendationFile(
+  value: unknown,
+): asserts value is SessionStartupRecommendationFile {
+  if (
+    !value ||
+    typeof value !== "object" ||
+    typeof (value as Record<string, unknown>).rank !== "number" ||
+    typeof (value as Record<string, unknown>).path !== "string" ||
+    typeof (value as Record<string, unknown>).sourceType !== "string" ||
+    typeof (value as Record<string, unknown>).title !== "string" ||
+    typeof (value as Record<string, unknown>).rationale !== "string" ||
+    !Array.isArray((value as Record<string, unknown>).sections)
+  ) {
+    throw new Error("Invalid recommend-startup payload: malformed recommended file entry");
+  }
+
+  for (const section of (value as Record<string, unknown>).sections as unknown[]) {
+    validateRecommendationSection(section);
+  }
+}
+
+function validateRecommendationPayload(
+  value: unknown,
+): asserts value is StartupContextRecommendationPayload {
+  if (
+    !value ||
+    typeof value !== "object" ||
+    typeof (value as Record<string, unknown>).corpus !== "string" ||
+    typeof (value as Record<string, unknown>).task !== "string" ||
+    typeof (value as Record<string, unknown>).generatedAt !== "string" ||
+    typeof (value as Record<string, unknown>).indexVersion !== "string" ||
+    !Array.isArray((value as Record<string, unknown>).recommendedFiles)
+  ) {
+    throw new Error("Invalid recommend-startup payload: missing top-level fields");
+  }
+
+  for (const item of (value as Record<string, unknown>).recommendedFiles as unknown[]) {
+    validateRecommendationFile(item);
+  }
+}
+
+export function classifyStartupTaskShape(
+  task: string | undefined,
+): SessionStartupAdvisory["taskShape"] {
+  const normalized = (task ?? "").trim().toLowerCase();
+  if (!normalized) {
+    return "general";
+  }
+
+  if (isSourceDiscoveryTask(normalized)) {
+    return "source_discovery";
+  }
+
+  if (
+    /(debug|bug|error|failing|failure|traceback|incident|cron|runtime|router|crash|broken|fix)/i.test(
+      normalized,
+    )
+  ) {
+    return "debug_runtime";
+  }
+
+  if (
+    /(research|analy[sz]e|compare|paper|pdf|whitepaper|report|long doc|long-document|study|survey|read and summarize)/i.test(
+      normalized,
+    )
+  ) {
+    return "research_long_doc";
+  }
+
+  if (isSkillRoutingPolicyTask(normalized)) {
+    return "skill_routing_policy";
+  }
+
+  return "general";
+}
+
+export function resolveStartupRouteContract(
+  taskShape: SessionStartupAdvisory["taskShape"],
+): StartupRouteContract {
+  switch (taskShape) {
+    case "source_discovery":
+      return {
+        routeMode: "workflow",
+        skillHints: ["ll", "bb"],
+        workflowHints: [
+          'll 调研 "<goal>"',
+          "ll 网页 <url>",
+          "bb open <url> (only if low-level page inspection is still needed)",
+        ],
+        routeReason:
+          "When a direct source read fails with 404 or an unresolved repo/link guess, escalate into source discovery: use ll first for read-only discovery and only drop to bb for low-level browser inspection.",
+      };
+    case "debug_runtime":
+      return {
+        routeMode: "skill",
+        skillHints: ["runtime-debug-playbook"],
+        workflowHints: [],
+        routeReason:
+          "Debug/runtime tasks stay primarily skill-routed because diagnosis and sequencing are still judgment-heavy.",
+      };
+    case "skill_routing_policy":
+      return {
+        routeMode: "skill",
+        skillHints: ["global-rules", "skill-health-check"],
+        workflowHints: [],
+        routeReason:
+          "Routing and policy tasks should stay on model-routed skills unless they harden into a stable artifact workflow.",
+      };
+    case "research_long_doc":
+      return {
+        routeMode: "hybrid",
+        skillHints: [],
+        workflowHints: ["/context recommend <task>"],
+        routeReason:
+          "Long-doc research benefits from soft skill routing plus an explicit retrieval workflow for repeatable evidence gathering.",
+      };
+    case "general":
+    default:
+      return {
+        routeMode: "skill",
+        skillHints: [],
+        workflowHints: [],
+        routeReason:
+          "General startup keeps the default skill-routed path unless a repeatable operator workflow clearly fits better.",
+      };
+  }
+}
+
+export async function fetchStartupContextRecommendations(
+  task: string,
+  options?: {
+    binPath?: string;
+    limitFiles?: number;
+    sectionsPerFile?: number;
+    timeoutMs?: number;
+  },
+): Promise<StartupContextRecommendationPayload> {
+  const binPath =
+    options?.binPath ??
+    process.env.OPENCLAW_RECOMMEND_STARTUP_CONTEXT_BIN ??
+    DEFAULT_RECOMMEND_BIN;
+  const args = [
+    "--task",
+    task,
+    "--limit-files",
+    String(options?.limitFiles ?? 3),
+    "--sections-per-file",
+    String(options?.sectionsPerFile ?? 2),
+  ];
+  const result = await execFileUtf8(binPath, args, {
+    timeout: options?.timeoutMs ?? DEFAULT_RECOMMEND_TIMEOUT_MS,
+  });
+  let finalResult = result;
+  if (result.code !== 0) {
+    const pythonFallback = await resolvePythonFallbackInvocation(binPath, args);
+    if (pythonFallback) {
+      const retried = await execFileUtf8(pythonFallback.command, pythonFallback.args, {
+        timeout: options?.timeoutMs ?? DEFAULT_RECOMMEND_TIMEOUT_MS,
+      });
+      if (retried.code === 0 || (!retried.stderr && !retried.stdout)) {
+        finalResult = retried;
+      } else if (!result.stderr && !result.stdout) {
+        finalResult = retried;
+      }
+    }
+  }
+  if (finalResult.code !== 0) {
+    throw new Error(
+      `recommend-startup-context failed (${finalResult.code}): ${finalResult.stderr || finalResult.stdout || "unknown error"}`,
+    );
+  }
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(finalResult.stdout);
+  } catch (error) {
+    throw new Error(
+      `recommend-startup-context returned invalid JSON: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  validateRecommendationPayload(payload);
+  return payload;
+}
+
+async function buildFreshStartupContextAdvisory(params: {
+  task: string;
+  taskShape: SessionStartupAdvisory["taskShape"];
+  route: StartupRouteContract;
+  options?: {
+    limitFiles?: number;
+    sectionsPerFile?: number;
+    timeoutMs?: number;
+    binPath?: string;
+  };
+}): Promise<SessionStartupAdvisory> {
+  try {
+    const payload = await fetchStartupContextRecommendations(params.task, {
+      binPath: params.options?.binPath,
+      limitFiles: params.options?.limitFiles,
+      sectionsPerFile: params.options?.sectionsPerFile,
+      timeoutMs: params.options?.timeoutMs,
+    });
+    return {
+      mode: "advisory",
+      source: "pageindex-startup-context",
+      status: "ready",
+      taskShape: params.taskShape,
+      ...params.route,
+      note: "Advisory only. Review these after mandatory reads; nothing was auto-injected into the prompt.",
+      recommendationCount: payload.recommendedFiles.length,
+      generatedAt: payload.generatedAt,
+      indexVersion: payload.indexVersion,
+      recommendedFiles: payload.recommendedFiles,
+      autoAttachStatus: "not_eligible",
+      autoAttachNote: "Advisory generated, but auto-attach policy has not been evaluated yet.",
+      autoAttachedFiles: [],
+    };
+  } catch (error) {
+    return buildUnavailableStartupAdvisory({
+      taskShape: params.taskShape,
+      route: params.route,
+      note: "Startup advisory was attempted but unavailable. Bootstrap stayed unchanged.",
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+function scheduleStartupAdvisoryRefresh(params: {
+  task: string;
+  taskShape: SessionStartupAdvisory["taskShape"];
+  route: StartupRouteContract;
+  options?: {
+    limitFiles?: number;
+    sectionsPerFile?: number;
+    binPath?: string;
+  };
+}): void {
+  if (!supportsStartupAdvisoryCache(params.taskShape)) {
+    return;
+  }
+  const key = params.taskShape;
+  if (startupAdvisoryBackgroundRefreshes.has(key)) {
+    return;
+  }
+  const refreshPromise = (async () => {
+    const advisory = await buildFreshStartupContextAdvisory({
+      task: params.task,
+      taskShape: params.taskShape,
+      route: params.route,
+      options: {
+        ...params.options,
+        timeoutMs: BACKGROUND_REFRESH_TIMEOUT_MS,
+      },
+    });
+    if (advisory.status === "ready") {
+      await persistStartupAdvisoryCache({ task: params.task, advisory });
+      console.log("[startup-advisory] 后台刷新缓存完成");
+      return;
+    }
+    console.warn(
+      "[startup-advisory] 后台刷新失败，保留旧缓存:",
+      new Error(advisory.error ?? "unknown refresh failure"),
+    );
+  })()
+    .catch((error: unknown) => {
+      console.warn(
+        "[startup-advisory] 后台刷新失败，保留旧缓存:",
+        error instanceof Error ? error : new Error(String(error)),
+      );
+    })
+    .finally(() => {
+      startupAdvisoryBackgroundRefreshes.delete(key);
+    });
+  startupAdvisoryBackgroundRefreshes.set(key, refreshPromise);
+}
+
+export async function buildStartupContextAdvisory(
+  taskText: string | undefined,
+  options?: {
+    limitFiles?: number;
+    sectionsPerFile?: number;
+    timeoutMs?: number;
+    binPath?: string;
+    sessionKey?: string;
+    taskTextSource?: SessionTaskTextSource;
+  },
+): Promise<SessionStartupAdvisory | undefined> {
+  const task = taskText?.trim();
+  if (!task) {
+    const route = resolveStartupRouteContract("general");
+    const advisory: SessionStartupAdvisory = {
+      mode: "advisory",
+      source: "pageindex-startup-context",
+      status: "not_applicable",
+      taskShape: "general",
+      ...route,
+      note: "No task text available for this session.",
+      recommendationCount: 0,
+      recommendedFiles: [],
+    };
+    emitStartupAdvisoryReflection({
+      taskText,
+      taskShape: "general",
+      sessionKey: options?.sessionKey,
+      taskTextSource: options?.taskTextSource,
+      claimedOutcome: "startup_advisory_requested",
+      observedOutcome: "task_text_missing",
+      route,
+      advisory,
+      operatorActionable: advisory.note ?? "Capture task text at session start before relying on startup advisory.",
+    });
+    return advisory;
+  }
+
+  const taskShape = classifyStartupTaskShape(task);
+  const route = resolveStartupRouteContract(taskShape);
+  if (taskShape === "general") {
+    const advisory: SessionStartupAdvisory = {
+      mode: "advisory",
+      source: "pageindex-startup-context",
+      status: "not_applicable",
+      taskShape,
+      ...route,
+      note: "No focused startup recommendation profile matched this task. Bootstrap stayed on mandatory reads only.",
+      recommendationCount: 0,
+      recommendedFiles: [],
+    };
+    emitStartupAdvisoryReflection({
+      taskText: task,
+      taskShape,
+      sessionKey: options?.sessionKey,
+      taskTextSource: options?.taskTextSource,
+      claimedOutcome: "startup_advisory_requested",
+      observedOutcome: "classifier_short_circuit_general",
+      route,
+      advisory,
+      operatorActionable: advisory.note ?? "Escalate only if this recurring task needs a dedicated startup profile.",
+    });
+    return advisory;
+  }
+
+  if (taskShape === "source_discovery") {
+    const advisory: SessionStartupAdvisory = {
+      mode: "advisory",
+      source: "pageindex-startup-context",
+      status: "not_applicable",
+      taskShape,
+      ...route,
+      note: "Source discovery stays on the ll-first workflow path. PageIndex startup recommendation is skipped for unresolved-source tasks.",
+      recommendationCount: 0,
+      recommendedFiles: [],
+      autoAttachStatus: "not_eligible",
+      autoAttachNote:
+        "Auto-attach does not run for source discovery. Keep source lookup lightweight and operator-visible.",
+      autoAttachedFiles: [],
+    };
+    emitStartupAdvisoryReflection({
+      taskText: task,
+      taskShape,
+      sessionKey: options?.sessionKey,
+      taskTextSource: options?.taskTextSource,
+      claimedOutcome: "startup_advisory_requested",
+      observedOutcome: "classifier_short_circuit_source_discovery",
+      route,
+      advisory,
+      operatorActionable: advisory.note ?? "Stay on the ll-first source discovery path instead of PageIndex startup attach.",
+    });
+    return advisory;
+  }
+
+  const cachedAdvisory = await readStartupAdvisoryCache(taskShape);
+  if (cachedAdvisory) {
+    scheduleStartupAdvisoryRefresh({
+      task,
+      taskShape,
+      route,
+      options: {
+        binPath: options?.binPath,
+        limitFiles: options?.limitFiles,
+        sectionsPerFile: options?.sectionsPerFile,
+      },
+    });
+    const advisory = toCachedStartupAdvisory(cachedAdvisory);
+    emitStartupAdvisoryReflection({
+      taskText: task,
+      taskShape,
+      sessionKey: options?.sessionKey,
+      taskTextSource: options?.taskTextSource,
+      claimedOutcome: "fresh_advisory",
+      observedOutcome: "cached_advisory",
+      route,
+      advisory,
+      operatorActionable: advisory.note ?? CACHED_STARTUP_ADVISORY_NOTE,
+    });
+    return advisory;
+  }
+
+  const advisory = await buildFreshStartupContextAdvisory({
+    task,
+    taskShape,
+    route,
+    options: {
+      binPath: options?.binPath,
+      limitFiles: options?.limitFiles,
+      sectionsPerFile: options?.sectionsPerFile,
+      timeoutMs: options?.timeoutMs ?? INITIAL_UNCACHED_RECOMMEND_TIMEOUT_MS,
+    },
+  });
+  if (advisory.status === "ready") {
+    await persistStartupAdvisoryCache({ task, advisory });
+    emitStartupAdvisoryReflection({
+      taskText: task,
+      taskShape,
+      sessionKey: options?.sessionKey,
+      taskTextSource: options?.taskTextSource,
+      claimedOutcome: "fresh_advisory",
+      observedOutcome: "ready",
+      route,
+      advisory,
+      operatorActionable: advisory.note ?? "Review the recommended files before attaching more context.",
+    });
+    return advisory;
+  }
+  if (isTimeoutLikeStartupError(advisory.error)) {
+    scheduleStartupAdvisoryRefresh({
+      task,
+      taskShape,
+      route,
+      options: {
+        binPath: options?.binPath,
+        limitFiles: options?.limitFiles,
+        sectionsPerFile: options?.sectionsPerFile,
+      },
+    });
+    const timeoutAdvisory = {
+      ...advisory,
+      note: INITIAL_INDEXING_NOTE,
+      autoAttachStatus: "not_eligible",
+      autoAttachNote:
+        "Auto-attach did not run because startup advisory is still building its first cache.",
+    };
+    emitStartupAdvisoryReflection({
+      taskText: task,
+      taskShape,
+      sessionKey: options?.sessionKey,
+      taskTextSource: options?.taskTextSource,
+      claimedOutcome: "fresh_advisory",
+      observedOutcome: "advisory_unavailable_timeout",
+      route,
+      advisory: timeoutAdvisory,
+      operatorActionable: timeoutAdvisory.note ?? INITIAL_INDEXING_NOTE,
+    });
+    return timeoutAdvisory;
+  }
+  emitStartupAdvisoryReflection({
+    taskText: task,
+    taskShape,
+    sessionKey: options?.sessionKey,
+    taskTextSource: options?.taskTextSource,
+    claimedOutcome: "fresh_advisory",
+    observedOutcome: "advisory_unavailable",
+    route,
+    advisory,
+    operatorActionable:
+      advisory.autoAttachNote ??
+      advisory.note ??
+      "Inspect recommend-startup-context errors before trusting startup advisory coverage.",
+  });
+  return advisory;
+}
+
+function isEligibleAutoAttachPath(file: SessionStartupRecommendationFile): boolean {
+  if (file.sourceType === "incident") {
+    return true;
+  }
+  return file.sourceType === "docs" && file.path.includes("/docs/runbooks/");
+}
+
+function isEligiblePolicyAutoAttachPath(file: SessionStartupRecommendationFile): boolean {
+  if (file.sourceType !== "docs") {
+    return false;
+  }
+  return (
+    file.path.includes("/docs/context/") ||
+    file.path.includes("/docs/runbooks/") ||
+    file.path.includes("/rules/")
+  );
+}
+
+function topRecommendationScore(file: SessionStartupRecommendationFile): number {
+  return file.sections[0]?.score ?? 0;
+}
+
+async function loadAutoAttachCandidate(
+  file: SessionStartupRecommendationFile,
+): Promise<WorkspaceBootstrapFile> {
+  const fs = await import("node:fs/promises");
+  const path = await import("node:path");
+  const content = await fs.readFile(file.path, "utf8");
+  return {
+    name: path.basename(file.path),
+    path: file.path,
+    content,
+    missing: false,
+  };
+}
+
+export async function applyStartupAutoAttachPolicy(params: {
+  advisory: SessionStartupAdvisory | undefined;
+  contextFiles: EmbeddedContextFile[];
+  bootstrapFiles: WorkspaceBootstrapFile[];
+  bootstrapMaxChars: number;
+  bootstrapTotalMaxChars?: number;
+  sessionKey?: string;
+  taskTextSource?: SessionTaskTextSource;
+}): Promise<{
+  advisory: SessionStartupAdvisory | undefined;
+  contextFiles: EmbeddedContextFile[];
+}> {
+  const advisory = params.advisory;
+  if (!advisory) {
+    return { advisory, contextFiles: params.contextFiles };
+  }
+  if (advisory.source === "cached") {
+    const cachedResult = {
+      advisory: {
+        ...advisory,
+        autoAttachStatus: "not_eligible",
+        autoAttachNote: CACHED_STARTUP_AUTO_ATTACH_NOTE,
+        autoAttachedFiles: [],
+      },
+      contextFiles: params.contextFiles,
+    };
+    emitStartupAdvisoryReflection({
+      taskShape: advisory.taskShape,
+      sessionKey: params.sessionKey,
+      taskTextSource: params.taskTextSource,
+      claimedOutcome: "fresh_auto_attach",
+      observedOutcome: "auto_attach_skipped_cached",
+      advisory: cachedResult.advisory,
+      operatorActionable: cachedResult.advisory.autoAttachNote ?? CACHED_STARTUP_AUTO_ATTACH_NOTE,
+    });
+    return cachedResult;
+  }
+
+  if (advisory.status !== "ready") {
+    const unavailableResult = {
+      advisory: {
+        ...advisory,
+        autoAttachStatus: "not_eligible",
+        autoAttachNote:
+          advisory.autoAttachNote ?? "Auto-attach only runs when startup advisory is ready.",
+        autoAttachedFiles: [],
+      },
+      contextFiles: params.contextFiles,
+    };
+    emitStartupAdvisoryReflection({
+      taskShape: advisory.taskShape,
+      sessionKey: params.sessionKey,
+      taskTextSource: params.taskTextSource,
+      claimedOutcome: "fresh_auto_attach",
+      observedOutcome: "auto_attach_skipped_unready",
+      advisory: unavailableResult.advisory,
+      operatorActionable:
+        unavailableResult.advisory.autoAttachNote ??
+        "Wait for a ready startup advisory before auto-attaching files.",
+    });
+    return unavailableResult;
+  }
+
+  if (advisory.taskShape !== "debug_runtime") {
+    if (advisory.taskShape === "skill_routing_policy") {
+      const existingPaths = new Set([
+        ...params.bootstrapFiles.map((file) => file.path),
+        ...params.contextFiles.map((file) => file.path),
+      ]);
+      const candidate = advisory.recommendedFiles.find(
+        (file) =>
+          isEligiblePolicyAutoAttachPath(file) &&
+          topRecommendationScore(file) >= POLICY_AUTO_ATTACH_MIN_SCORE &&
+          !existingPaths.has(file.path),
+      );
+      if (!candidate) {
+        const skippedResult = {
+          advisory: {
+            ...advisory,
+            autoAttachStatus: "skipped",
+            autoAttachNote:
+              "No eligible policy/context recommendation met the v2 auto-attach policy.",
+            autoAttachedFiles: [],
+          },
+          contextFiles: params.contextFiles,
+        };
+        emitStartupAdvisoryReflection({
+          taskShape: advisory.taskShape,
+          sessionKey: params.sessionKey,
+          taskTextSource: params.taskTextSource,
+          claimedOutcome: "fresh_auto_attach",
+          observedOutcome: "auto_attach_skipped_no_candidate",
+          advisory: skippedResult.advisory,
+          operatorActionable: skippedResult.advisory.autoAttachNote ?? "No policy candidate met the attach threshold.",
+        });
+        return skippedResult;
+      }
+
+      const totalBudget = Math.max(params.bootstrapTotalMaxChars ?? params.bootstrapMaxChars, 1);
+      const usedBudget = params.contextFiles.reduce((sum, file) => sum + file.content.length, 0);
+      const remainingBudget = Math.max(0, totalBudget - usedBudget);
+      if (remainingBudget <= 0) {
+        const budgetResult = {
+          advisory: {
+            ...advisory,
+            autoAttachStatus: "skipped",
+            autoAttachNote:
+              "No remaining bootstrap context budget was available for policy auto-attach.",
+            autoAttachedFiles: [],
+          },
+          contextFiles: params.contextFiles,
+        };
+        emitStartupAdvisoryReflection({
+          taskShape: advisory.taskShape,
+          sessionKey: params.sessionKey,
+          taskTextSource: params.taskTextSource,
+          claimedOutcome: "fresh_auto_attach",
+          observedOutcome: "auto_attach_skipped_budget",
+          advisory: budgetResult.advisory,
+          operatorActionable: budgetResult.advisory.autoAttachNote ?? "Free bootstrap budget before auto-attaching more policy context.",
+        });
+        return budgetResult;
+      }
+
+      try {
+        const attachCandidate = await loadAutoAttachCandidate(candidate);
+        const attachedContextFiles = buildBootstrapContextFiles([attachCandidate], {
+          maxChars: Math.min(params.bootstrapMaxChars, POLICY_AUTO_ATTACH_MAX_CHARS),
+          totalMaxChars: remainingBudget,
+        });
+        if (!attachedContextFiles.length) {
+          const fitResult = {
+            advisory: {
+              ...advisory,
+              autoAttachStatus: "skipped",
+              autoAttachNote:
+                "The chosen policy/context file could not fit inside the remaining context budget.",
+              autoAttachedFiles: [],
+            },
+            contextFiles: params.contextFiles,
+          };
+          emitStartupAdvisoryReflection({
+            taskShape: advisory.taskShape,
+            sessionKey: params.sessionKey,
+            taskTextSource: params.taskTextSource,
+            claimedOutcome: "fresh_auto_attach",
+            observedOutcome: "auto_attach_skipped_budget_fit",
+            advisory: fitResult.advisory,
+            operatorActionable: fitResult.advisory.autoAttachNote ?? "Trim context before retrying policy auto-attach.",
+          });
+          return fitResult;
+        }
+
+        return {
+          advisory: {
+            ...advisory,
+            autoAttachStatus: "applied",
+            autoAttachNote:
+              "Auto-attach v2 added one high-confidence policy/context reference to the prompt context.",
+            autoAttachedFiles: attachedContextFiles.map((file) => file.path),
+          },
+          contextFiles: [...params.contextFiles, ...attachedContextFiles],
+        };
+      } catch (error) {
+        const failedResult = {
+          advisory: {
+            ...advisory,
+            autoAttachStatus: "skipped",
+            autoAttachNote: "Failed to read the chosen policy/context file for auto-attach.",
+            autoAttachedFiles: [],
+            error: advisory.error ?? (error instanceof Error ? error.message : String(error)),
+          },
+          contextFiles: params.contextFiles,
+        };
+        emitStartupAdvisoryReflection({
+          taskShape: advisory.taskShape,
+          sessionKey: params.sessionKey,
+          taskTextSource: params.taskTextSource,
+          claimedOutcome: "fresh_auto_attach",
+          observedOutcome: "auto_attach_failed_read",
+          advisory: failedResult.advisory,
+          operatorActionable: failedResult.advisory.autoAttachNote ?? "Fix file access before retrying policy auto-attach.",
+        });
+        return failedResult;
+      }
+    }
+
+    if (advisory.taskShape === "source_discovery") {
+      const sourceDiscoveryResult = {
+        advisory: {
+          ...advisory,
+          autoAttachStatus: "not_eligible",
+          autoAttachNote:
+            "Auto-attach v1 does not run for source discovery; keep the fallback lightweight and operator-visible.",
+          autoAttachedFiles: [],
+        },
+        contextFiles: params.contextFiles,
+      };
+      emitStartupAdvisoryReflection({
+        taskShape: advisory.taskShape,
+        sessionKey: params.sessionKey,
+        taskTextSource: params.taskTextSource,
+        claimedOutcome: "fresh_auto_attach",
+        observedOutcome: "auto_attach_not_eligible_source_discovery",
+        advisory: sourceDiscoveryResult.advisory,
+        operatorActionable:
+          sourceDiscoveryResult.advisory.autoAttachNote ??
+          "Keep source discovery lightweight instead of auto-attaching extra files.",
+      });
+      return sourceDiscoveryResult;
+    }
+
+    const notEligibleResult = {
+      advisory: {
+        ...advisory,
+        autoAttachStatus: "not_eligible",
+        autoAttachNote: "Auto-attach is only enabled for debug/runtime and policy/context tasks.",
+        autoAttachedFiles: [],
+      },
+      contextFiles: params.contextFiles,
+    };
+    emitStartupAdvisoryReflection({
+      taskShape: advisory.taskShape,
+      sessionKey: params.sessionKey,
+      taskTextSource: params.taskTextSource,
+      claimedOutcome: "fresh_auto_attach",
+      observedOutcome: "auto_attach_not_eligible",
+      advisory: notEligibleResult.advisory,
+      operatorActionable:
+        notEligibleResult.advisory.autoAttachNote ??
+        "Only debug/runtime and policy tasks are currently eligible for startup auto-attach.",
+    });
+    return notEligibleResult;
+  }
+
+  const existingPaths = new Set([
+    ...params.bootstrapFiles.map((file) => file.path),
+    ...params.contextFiles.map((file) => file.path),
+  ]);
+  const candidate = advisory.recommendedFiles.find(
+    (file) =>
+      isEligibleAutoAttachPath(file) &&
+      topRecommendationScore(file) >= AUTO_ATTACH_MIN_SCORE &&
+      !existingPaths.has(file.path),
+  );
+
+  if (!candidate) {
+    const skippedResult = {
+      advisory: {
+        ...advisory,
+        autoAttachStatus: "skipped",
+        autoAttachNote:
+          "No eligible debug/runtime recommendation met the v1 auto-attach policy.",
+        autoAttachedFiles: [],
+      },
+      contextFiles: params.contextFiles,
+    };
+    emitStartupAdvisoryReflection({
+      taskShape: advisory.taskShape,
+      sessionKey: params.sessionKey,
+      taskTextSource: params.taskTextSource,
+      claimedOutcome: "fresh_auto_attach",
+      observedOutcome: "auto_attach_skipped_no_candidate",
+      advisory: skippedResult.advisory,
+      operatorActionable:
+        skippedResult.advisory.autoAttachNote ?? "No debug/runtime candidate met the attach threshold.",
+    });
+    return skippedResult;
+  }
+
+  const totalBudget = Math.max(params.bootstrapTotalMaxChars ?? params.bootstrapMaxChars, 1);
+  const usedBudget = params.contextFiles.reduce((sum, file) => sum + file.content.length, 0);
+  const remainingBudget = Math.max(0, totalBudget - usedBudget);
+  if (remainingBudget <= 0) {
+    const budgetResult = {
+      advisory: {
+        ...advisory,
+        autoAttachStatus: "skipped",
+        autoAttachNote: "No remaining bootstrap context budget was available for auto-attach.",
+        autoAttachedFiles: [],
+      },
+      contextFiles: params.contextFiles,
+    };
+    emitStartupAdvisoryReflection({
+      taskShape: advisory.taskShape,
+      sessionKey: params.sessionKey,
+      taskTextSource: params.taskTextSource,
+      claimedOutcome: "fresh_auto_attach",
+      observedOutcome: "auto_attach_skipped_budget",
+      advisory: budgetResult.advisory,
+      operatorActionable: budgetResult.advisory.autoAttachNote ?? "Free context budget before retrying auto-attach.",
+    });
+    return budgetResult;
+  }
+
+  try {
+    const attachCandidate = await loadAutoAttachCandidate(candidate);
+    const attachedContextFiles = buildBootstrapContextFiles([attachCandidate], {
+      maxChars: Math.min(params.bootstrapMaxChars, AUTO_ATTACH_MAX_CHARS),
+      totalMaxChars: remainingBudget,
+    });
+    if (!attachedContextFiles.length) {
+      const fitResult = {
+        advisory: {
+          ...advisory,
+          autoAttachStatus: "skipped",
+          autoAttachNote: "The chosen startup file could not fit inside the remaining context budget.",
+          autoAttachedFiles: [],
+        },
+        contextFiles: params.contextFiles,
+      };
+      emitStartupAdvisoryReflection({
+        taskShape: advisory.taskShape,
+        sessionKey: params.sessionKey,
+        taskTextSource: params.taskTextSource,
+        claimedOutcome: "fresh_auto_attach",
+        observedOutcome: "auto_attach_skipped_budget_fit",
+        advisory: fitResult.advisory,
+        operatorActionable: fitResult.advisory.autoAttachNote ?? "Trim context before retrying startup auto-attach.",
+      });
+      return fitResult;
+    }
+
+    return {
+      advisory: {
+        ...advisory,
+        autoAttachStatus: "applied",
+        autoAttachNote:
+          "Auto-attach v1 added one high-confidence debug/runtime reference to the prompt context.",
+        autoAttachedFiles: attachedContextFiles.map((file) => file.path),
+      },
+      contextFiles: [...params.contextFiles, ...attachedContextFiles],
+    };
+  } catch (error) {
+    const failedResult = {
+      advisory: {
+        ...advisory,
+        autoAttachStatus: "skipped",
+        autoAttachNote: "Failed to read the chosen startup file for auto-attach.",
+        autoAttachedFiles: [],
+        error: advisory.error ?? (error instanceof Error ? error.message : String(error)),
+      },
+      contextFiles: params.contextFiles,
+    };
+    emitStartupAdvisoryReflection({
+      taskShape: advisory.taskShape,
+      sessionKey: params.sessionKey,
+      taskTextSource: params.taskTextSource,
+      claimedOutcome: "fresh_auto_attach",
+      observedOutcome: "auto_attach_failed_read",
+      advisory: failedResult.advisory,
+      operatorActionable: failedResult.advisory.autoAttachNote ?? "Fix file access before retrying startup auto-attach.",
+    });
+    return failedResult;
+  }
+}

--- a/src/auto-reply/reply/commands-context-recommend.test.ts
+++ b/src/auto-reply/reply/commands-context-recommend.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from "vitest";
+
+const execFileUtf8Mock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../daemon/exec-file.js", () => ({
+  execFileUtf8: execFileUtf8Mock,
+}));
+
+import {
+  buildRecommendationText,
+  fetchStartupContextRecommendations,
+} from "./commands-context-recommend.js";
+
+describe("fetchStartupContextRecommendations", () => {
+  it("calls the shared recommend script and parses the stable JSON payload", async () => {
+    execFileUtf8Mock.mockResolvedValueOnce({
+      code: 0,
+      stdout: JSON.stringify({
+        corpus: "openclaw-internal-knowledge",
+        task: "debug cron routing",
+        generatedAt: "2026-03-18T10:00:00Z",
+        indexVersion: "test-version",
+        recommendedFiles: [
+          {
+            rank: 1,
+            path: "/tmp/cron-runbook.md",
+            sourceType: "runbook",
+            title: "Cron Runbook",
+            rationale: "Top runbook match after mandatory reads.",
+            sections: [
+              {
+                section: "Cron > Router",
+                excerpt: "Investigate the router script first.",
+                score: 12.5,
+              },
+            ],
+          },
+        ],
+      }),
+      stderr: "",
+    });
+
+    const payload = await fetchStartupContextRecommendations("debug cron routing", {
+      binPath: "/tmp/recommend-startup-context",
+      limitFiles: 2,
+      sectionsPerFile: 1,
+    });
+
+    expect(execFileUtf8Mock).toHaveBeenCalledWith("/tmp/recommend-startup-context", [
+      "--task",
+      "debug cron routing",
+      "--limit-files",
+      "2",
+      "--sections-per-file",
+      "1",
+    ], {
+      timeout: 8000,
+    });
+    expect(payload.recommendedFiles[0]?.path).toBe("/tmp/cron-runbook.md");
+  });
+
+  it("fails clearly when the script returns invalid JSON", async () => {
+    execFileUtf8Mock.mockResolvedValueOnce({
+      code: 0,
+      stdout: "not-json",
+      stderr: "",
+    });
+
+    await expect(fetchStartupContextRecommendations("debug cron routing")).rejects.toThrow(
+      "invalid JSON",
+    );
+  });
+});
+
+describe("buildRecommendationText", () => {
+  it("formats a compact operator-facing recommendation summary", () => {
+    const text = buildRecommendationText({
+      corpus: "openclaw-internal-knowledge",
+      task: "debug cron routing",
+      generatedAt: "2026-03-18T10:00:00Z",
+      indexVersion: "test-version",
+      recommendedFiles: [
+        {
+          rank: 1,
+          path: "/tmp/cron-runbook.md",
+          sourceType: "runbook",
+          title: "Cron Runbook",
+          rationale: "Top runbook match after mandatory reads.",
+          sections: [
+            {
+              section: "Cron > Router",
+              excerpt: "Investigate the router script first.",
+              score: 12.5,
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(text).toContain("🧭 Context recommendations");
+    expect(text).toContain("/tmp/cron-runbook.md");
+    expect(text).toContain("Cron > Router");
+    expect(text).toContain("Investigate the router script first.");
+  });
+});

--- a/src/auto-reply/reply/commands-context-recommend.ts
+++ b/src/auto-reply/reply/commands-context-recommend.ts
@@ -1,0 +1,66 @@
+import {
+  fetchStartupContextRecommendations,
+  type StartupContextRecommendationPayload,
+} from "../../agents/startup-advisory.js";
+import type { ReplyPayload } from "../types.js";
+
+export { fetchStartupContextRecommendations };
+
+function formatScore(score: number): string {
+  return Number.isInteger(score) ? score.toFixed(0) : score.toFixed(1);
+}
+
+export function buildRecommendationText(
+  payload: StartupContextRecommendationPayload,
+  options?: { note?: string },
+): string {
+  const lines = [
+    "🧭 Context recommendations",
+    `Task: ${payload.task}`,
+    options?.note ?? "Use after the mandatory reads from AGENTS.md / CLAUDE.md.",
+  ];
+
+  if (!payload.recommendedFiles.length) {
+    lines.push("", "No strong internal-knowledge matches found.");
+    return lines.join("\n");
+  }
+
+  for (const file of payload.recommendedFiles) {
+    lines.push("", `${file.rank}. ${file.path}`);
+    lines.push(`   ${file.rationale}`);
+    for (const section of file.sections) {
+      lines.push(`   - ${section.section} (score ${formatScore(section.score)})`);
+      if (section.excerpt) {
+        lines.push(`     ${section.excerpt}`);
+      }
+    }
+  }
+
+  return lines.join("\n");
+}
+
+export async function buildContextRecommendReply(
+  task: string,
+  options?: {
+    json?: boolean;
+    note?: string;
+  },
+): Promise<ReplyPayload> {
+  try {
+    const payload = await fetchStartupContextRecommendations(task);
+    if (options?.json) {
+      return { text: JSON.stringify(payload, null, 2) };
+    }
+    return { text: buildRecommendationText(payload, { note: options?.note }) };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      text: [
+        "Context recommendation failed.",
+        message,
+        "",
+        "Tip: run /context detail for the current session or doctor the shared PageIndex layer.",
+      ].join("\n"),
+    };
+  }
+}

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -318,8 +318,68 @@ export type SessionSkillSnapshot = {
   version?: number;
 };
 
+export type SessionStartupRecommendationSection = {
+  section: string;
+  excerpt: string;
+  score: number;
+};
+
+export type SessionStartupRecommendationFile = {
+  rank: number;
+  path: string;
+  sourceType: string;
+  title: string;
+  rationale: string;
+  sections: SessionStartupRecommendationSection[];
+};
+
+export const SESSION_TASK_TEXT_SOURCE_VALUES = [
+  "prompt",
+  "history",
+  "extra_system_prompt",
+  "none",
+  "cli_direct",
+  "webhook",
+  "followup_queue",
+  "cron_trigger",
+  "openai_http",
+  "openresponses_http",
+  "boot_prompt",
+  "node_voice",
+  "node_request",
+] as const;
+
+export type SessionTaskTextSource =
+  | (typeof SESSION_TASK_TEXT_SOURCE_VALUES)[number];
+
+export type SessionStartupAdvisory = {
+  mode: "advisory";
+  source: "pageindex-startup-context" | "cached";
+  status: "ready" | "unavailable" | "not_applicable";
+  taskShape:
+    | "debug_runtime"
+    | "skill_routing_policy"
+    | "research_long_doc"
+    | "source_discovery"
+    | "general";
+  routeMode?: "skill" | "workflow" | "hybrid";
+  skillHints?: string[];
+  workflowHints?: string[];
+  routeReason?: string;
+  note: string;
+  recommendationCount: number;
+  generatedAt?: string;
+  indexVersion?: string;
+  recommendedFiles: SessionStartupRecommendationFile[];
+  autoAttachStatus?: "applied" | "skipped" | "not_eligible";
+  autoAttachNote?: string;
+  autoAttachedFiles?: string[];
+  error?: string;
+};
+
 export type SessionSystemPromptReport = {
   source: "run" | "estimate";
+  detailLevel?: "full" | "summary";
   generatedAt: number;
   sessionId?: string;
   sessionKey?: string;
@@ -337,6 +397,10 @@ export type SessionSystemPromptReport = {
     nearLimitFiles?: number;
     totalNearLimit?: boolean;
   };
+  taskTextChars?: number;
+  taskTextSource?: SessionTaskTextSource;
+  taskTextPreview?: string;
+  startupAdvisory?: SessionStartupAdvisory;
   sandbox?: {
     mode?: string;
     sandboxed?: boolean;


### PR DESCRIPTION
## Summary

This PR restores clean-checkout source integrity for the startup-advisory and runtime-reflection path.

It tracks the source modules that were already being imported by command, status, and cron surfaces, but were not yet checked in as source files on the landing branch.

## Why this PR is the right landing PR

This stack has three logical layers:

1. source integrity
2. failover telemetry
3. CLI JSON purity

This PR is the first layer. It restores the baseline repository contract that a clean checkout should build from tracked source only.

Without this, later runtime and operator-facing changes can look green in a dirty tree while still failing in clean verification.

## Follow-up stack

The follow-up PRs remain in the fork stack for review sequencing:

- Failover telemetry: https://github.com/qq919927036-glitch/openclaw-zero-token/pull/2
- JSON purity: https://github.com/qq919927036-glitch/openclaw-zero-token/pull/1

## Problem

The branch could appear to work in a dirty worktree, but clean-checkout builds failed because imports were resolving to files that only existed as untracked local changes.

That breaks the most basic repository contract:

- a clean checkout should build
- a tracked import should resolve from tracked source
- status/context/cron surfaces should not depend on local untracked files

## What changed

- tracks `src/agents/runtime-reflection.ts`
- tracks `src/agents/startup-advisory.ts`
- tracks `src/auto-reply/reply/commands-context-recommend.ts`
- extends `src/config/sessions/types.ts` with the startup-advisory/task-text contracts those modules require
- tracks the corresponding tests for the above modules

## Validation

Validated in a clean worktree:

```bash
pnpm exec vitest run \
  src/agents/runtime-reflection.test.ts \
  src/agents/startup-advisory.test.ts \
  src/auto-reply/reply/commands-context-recommend.test.ts
pnpm exec vitest run src/commands/status.e2e.test.ts
pnpm build
```

## Non-goals

This PR does not:

- change model failover semantics
- change CLI JSON stdout routing
- introduce live self-modification
- bundle unrelated `/memory` or operator workflow work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新增功能**
  * 添加运行时反射系统，用于持久化和检索操作工件，增强可追踪性
  * 实现启动顾问功能，自动分类任务并提供智能上下文建议
  * 支持自动附加策略，根据顾问状态有条件地注入推荐文件
  * 新增上下文推荐命令，以文本或JSON格式返回相关文件建议

* **测试**
  * 新增运行时反射、启动顾问和上下文推荐的完整测试覆盖

<!-- end of auto-generated comment: release notes by coderabbit.ai -->