### PR TITLE
feat: upgrade MiniMax default model to M2.7

### DIFF
--- a/docs/gateway/configuration-examples.md
+++ b/docs/gateway/configuration-examples.md
@@ -566,7 +566,7 @@ terms before depending on subscription auth.
     workspace: "~/.openclaw/workspace",
     model: {
       primary: "anthropic/claude-opus-4-6",
-      fallbacks: ["minimax/MiniMax-M2.5"],
+      fallbacks: ["minimax/MiniMax-M2.7"],
     },
   },
 }

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -863,11 +863,11 @@ Time format in system prompt. Default: `auto` (OS preference).
     defaults: {
       models: {
         "anthropic/claude-opus-4-6": { alias: "opus" },
-        "minimax/MiniMax-M2.5": { alias: "minimax" },
+        "minimax/MiniMax-M2.7": { alias: "minimax" },
       },
       model: {
         primary: "anthropic/claude-opus-4-6",
-        fallbacks: ["minimax/MiniMax-M2.5"],
+        fallbacks: ["minimax/MiniMax-M2.7"],
       },
       imageModel: {
         primary: "openrouter/qwen/qwen-2.5-vl-72b-instruct:free",
@@ -1960,7 +1960,7 @@ Notes:
   agents: {
     defaults: {
       subagents: {
-        model: "minimax/MiniMax-M2.5",
+        model: "minimax/MiniMax-M2.7",
         maxConcurrent: 1,
         runTimeoutSeconds: 900,
         archiveAfterMinutes: 60,
@@ -2211,15 +2211,15 @@ Base URL should omit `/v1` (Anthropic client appends it). Shortcut: `openclaw on
 
 </Accordion>
 
-<Accordion title="MiniMax M2.5 (direct)">
+<Accordion title="MiniMax M2.7 (direct)">
 
 ```json5
 {
   agents: {
     defaults: {
-      model: { primary: "minimax/MiniMax-M2.5" },
+      model: { primary: "minimax/MiniMax-M2.7" },
       models: {
-        "minimax/MiniMax-M2.5": { alias: "Minimax" },
+        "minimax/MiniMax-M2.7": { alias: "Minimax" },
       },
     },
   },
@@ -2232,9 +2232,9 @@ Base URL should omit `/v1` (Anthropic client appends it). Shortcut: `openclaw on
         api: "anthropic-messages",
         models: [
           {
-            id: "MiniMax-M2.5",
-            name: "MiniMax M2.5",
-            reasoning: false,
+            id: "MiniMax-M2.7",
+            name: "MiniMax M2.7",
+            reasoning: true,
             input: ["text"],
             cost: { input: 15, output: 60, cacheRead: 2, cacheWrite: 10 },
             contextWindow: 200000,

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -148,7 +148,7 @@ Quick answers plus deeper troubleshooting for real-world setups (local dev, VPS,
   - [How do I switch models on the fly (without restarting)?](#how-do-i-switch-models-on-the-fly-without-restarting)
   - [Can I use GPT 5.2 for daily tasks and Codex 5.3 for coding](#can-i-use-gpt-52-for-daily-tasks-and-codex-53-for-coding)
   - [Why do I see "Model … is not allowed" and then no reply?](#why-do-i-see-model-is-not-allowed-and-then-no-reply)
-  - [Why do I see "Unknown model: minimax/MiniMax-M2.5"?](#why-do-i-see-unknown-model-minimaxminimaxm25)
+  - [Why do I see "Unknown model: minimax/MiniMax-M2.7"?](#why-do-i-see-unknown-model-minimaxminimaxm27)
   - [Can I use MiniMax as my default and OpenAI for complex tasks?](#can-i-use-minimax-as-my-default-and-openai-for-complex-tasks)
   - [Are opus / sonnet / gpt built-in shortcuts?](#are-opus-sonnet-gpt-builtin-shortcuts)
   - [How do I define/override model shortcuts (aliases)?](#how-do-i-defineoverride-model-shortcuts-aliases)
@@ -2181,7 +2181,7 @@ Model "provider/model" is not allowed. Use /model to list available models.
 That error is returned **instead of** a normal reply. Fix: add the model to
 `agents.defaults.models`, remove the allowlist, or pick a model from `/model list`.
 
-### Why do I see Unknown model minimaxMiniMaxM25
+### Why do I see Unknown model minimaxMiniMaxM27
 
 This means the **provider isn't configured** (no MiniMax provider config or auth
 profile was found), so the model can't be resolved. A fix for this detection is
@@ -2192,8 +2192,8 @@ Fix checklist:
 1. Upgrade to **2026.1.12** (or run from source `main`), then restart the gateway.
 2. Make sure MiniMax is configured (wizard or JSON), or that a MiniMax API key
    exists in env/auth profiles so the provider can be injected.
-3. Use the exact model id (case-sensitive): `minimax/MiniMax-M2.5` or
-   `minimax/MiniMax-M2.5-highspeed`.
+3. Use the exact model id (case-sensitive): `minimax/MiniMax-M2.7` or
+   `minimax/MiniMax-M2.7-highspeed`.
 4. Run:
 
    ```bash
@@ -2216,9 +2216,9 @@ Fallbacks are for **errors**, not "hard tasks," so use `/model` or a separate ag
   env: { MINIMAX_API_KEY: "sk-...", OPENAI_API_KEY: "sk-..." },
   agents: {
     defaults: {
-      model: { primary: "minimax/MiniMax-M2.5" },
+      model: { primary: "minimax/MiniMax-M2.7" },
       models: {
-        "minimax/MiniMax-M2.5": { alias: "minimax" },
+        "minimax/MiniMax-M2.7": { alias: "minimax" },
         "openai/gpt-5.2": { alias: "gpt" },
       },
     },

--- a/docs/providers/minimax.md
+++ b/docs/providers/minimax.md
@@ -1,5 +1,5 @@
 ---
-summary: "Use MiniMax M2.5 in OpenClaw"
+summary: "Use MiniMax M2.7 in OpenClaw"
 read_when:
   - You want MiniMax models in OpenClaw
   - You need MiniMax setup guidance
@@ -8,30 +8,28 @@ title: "MiniMax"
 
 # MiniMax
 
-MiniMax is an AI company that builds the **M2/M2.5** model family. The current
-coding-focused release is **MiniMax M2.5** (December 23, 2025), built for
-real-world complex tasks.
+MiniMax is an AI company that builds the **M2/M2.5/M2.7** model family. The current
+coding-focused release is **MiniMax M2.7** (March 2026), built for
+real-world complex tasks with enhanced reasoning and coding capabilities.
 
-Source: [MiniMax M2.5 release note](https://www.minimax.io/news/minimax-m25)
+Source: [MiniMax M2.7 release note](https://www.minimax.io/news/minimax-m27-en)
 
-## Model overview (M2.5)
+## Model overview (M2.7)
 
-MiniMax highlights these improvements in M2.5:
+MiniMax highlights these improvements in M2.7:
 
+- Enhanced **reasoning and coding** capabilities.
 - Stronger **multi-language coding** (Rust, Java, Go, C++, Kotlin, Objective-C, TS/JS).
 - Better **web/app development** and aesthetic output quality (including native mobile).
-- Improved **composite instruction** handling for office-style workflows, building on
-  interleaved thinking and integrated constraint execution.
+- Improved **composite instruction** handling for office-style workflows.
 - **More concise responses** with lower token usage and faster iteration loops.
-- Stronger **tool/agent framework** compatibility and context management (Claude Code,
-  Droid/Factory AI, Cline, Kilo Code, Roo Code, BlackBox).
-- Higher-quality **dialogue and technical writing** outputs.
+- Stronger **tool/agent framework** compatibility and context management.
 
-## MiniMax M2.5 vs MiniMax M2.5 Highspeed
+## MiniMax M2.7 vs MiniMax M2.7 Highspeed
 
-- **Speed:** `MiniMax-M2.5-highspeed` is the official fast tier in MiniMax docs.
+- **Speed:** `MiniMax-M2.7-highspeed` is the official fast tier.
 - **Cost:** MiniMax pricing lists the same input cost and a higher output cost for highspeed.
-- **Current model IDs:** use `MiniMax-M2.5` or `MiniMax-M2.5-highspeed`.
+- **Current model IDs:** use `MiniMax-M2.7` or `MiniMax-M2.7-highspeed`.
 
 ## Choose a setup
 
@@ -54,7 +52,7 @@ You will be prompted to select an endpoint:
 
 See [MiniMax OAuth plugin README](https://github.com/openclaw/openclaw/tree/main/extensions/minimax-portal-auth) for details.
 
-### MiniMax M2.5 (API key)
+### MiniMax M2.7 (API key)
 
 **Best for:** hosted MiniMax with Anthropic-compatible API.
 
@@ -62,12 +60,12 @@ Configure via CLI:
 
 - Run `openclaw configure`
 - Select **Model/auth**
-- Choose **MiniMax M2.5**
+- Choose **MiniMax M2.7**
 
 ```json5
 {
   env: { MINIMAX_API_KEY: "sk-..." },
-  agents: { defaults: { model: { primary: "minimax/MiniMax-M2.5" } } },
+  agents: { defaults: { model: { primary: "minimax/MiniMax-M2.7" } } },
   models: {
     mode: "merge",
     providers: {
@@ -77,8 +75,8 @@ Configure via CLI:
         api: "anthropic-messages",
         models: [
           {
-            id: "MiniMax-M2.5",
-            name: "MiniMax M2.5",
+            id: "MiniMax-M2.7",
+            name: "MiniMax M2.7",
             reasoning: true,
             input: ["text"],
             cost: { input: 0.3, output: 1.2, cacheRead: 0.03, cacheWrite: 0.12 },
@@ -86,8 +84,8 @@ Configure via CLI:
             maxTokens: 8192,
           },
           {
-            id: "MiniMax-M2.5-highspeed",
-            name: "MiniMax M2.5 Highspeed",
+            id: "MiniMax-M2.7-highspeed",
+            name: "MiniMax M2.7 Highspeed",
             reasoning: true,
             input: ["text"],
             cost: { input: 0.3, output: 1.2, cacheRead: 0.03, cacheWrite: 0.12 },
@@ -101,9 +99,9 @@ Configure via CLI:
 }
 ```
 
-### MiniMax M2.5 as fallback (example)
+### MiniMax M2.7 as fallback (example)
 
-**Best for:** keep your strongest latest-generation model as primary, fail over to MiniMax M2.5.
+**Best for:** keep your strongest latest-generation model as primary, fail over to MiniMax M2.7.
 Example below uses Opus as a concrete primary; swap to your preferred latest-gen primary model.
 
 ```json5
@@ -113,11 +111,11 @@ Example below uses Opus as a concrete primary; swap to your preferred latest-gen
     defaults: {
       models: {
         "anthropic/claude-opus-4-6": { alias: "primary" },
-        "minimax/MiniMax-M2.5": { alias: "minimax" },
+        "minimax/MiniMax-M2.7": { alias: "minimax" },
       },
       model: {
         primary: "anthropic/claude-opus-4-6",
-        fallbacks: ["minimax/MiniMax-M2.5"],
+        fallbacks: ["minimax/MiniMax-M2.7"],
       },
     },
   },
@@ -170,7 +168,7 @@ Use the interactive config wizard to set MiniMax without editing JSON:
 
 1. Run `openclaw configure`.
 2. Select **Model/auth**.
-3. Choose **MiniMax M2.5**.
+3. Choose **MiniMax M2.7**.
 4. Pick your default model when prompted.
 
 ## Configuration options
@@ -185,30 +183,30 @@ Use the interactive config wizard to set MiniMax without editing JSON:
 ## Notes
 
 - Model refs are `minimax/<model>`.
-- Recommended model IDs: `MiniMax-M2.5` and `MiniMax-M2.5-highspeed`.
+- Recommended model IDs: `MiniMax-M2.7` and `MiniMax-M2.7-highspeed`.
 - Coding Plan usage API: `https://api.minimaxi.com/v1/api/openplatform/coding_plan/remains` (requires a coding plan key).
 - Update pricing values in `models.json` if you need exact cost tracking.
 - Referral link for MiniMax Coding Plan (10% off): [https://platform.minimax.io/subscribe/coding-plan?code=DbXJTRClnb&source=link](https://platform.minimax.io/subscribe/coding-plan?code=DbXJTRClnb&source=link)
 - See [/concepts/model-providers](/concepts/model-providers) for provider rules.
-- Use `openclaw models list` and `openclaw models set minimax/MiniMax-M2.5` to switch.
+- Use `openclaw models list` and `openclaw models set minimax/MiniMax-M2.7` to switch.
 
 ## Troubleshooting
 
-### “Unknown model: minimax/MiniMax-M2.5”
+### “Unknown model: minimax/MiniMax-M2.7”
 
 This usually means the **MiniMax provider isn’t configured** (no provider entry
 and no MiniMax auth profile/env key found). A fix for this detection is in
 **2026.1.12** (unreleased at the time of writing). Fix by:
 
 - Upgrading to **2026.1.12** (or run from source `main`), then restarting the gateway.
-- Running `openclaw configure` and selecting **MiniMax M2.5**, or
+- Running `openclaw configure` and selecting **MiniMax M2.7**, or
 - Adding the `models.providers.minimax` block manually, or
 - Setting `MINIMAX_API_KEY` (or a MiniMax auth profile) so the provider can be injected.
 
 Make sure the model id is **case‑sensitive**:
 
-- `minimax/MiniMax-M2.5`
-- `minimax/MiniMax-M2.5-highspeed`
+- `minimax/MiniMax-M2.7`
+- `minimax/MiniMax-M2.7-highspeed`
 
 Then recheck with:
 

--- a/extensions/minimax-portal-auth/index.ts
+++ b/extensions/minimax-portal-auth/index.ts
@@ -9,7 +9,7 @@ import { loginMiniMaxPortalOAuth, type MiniMaxRegion } from "./oauth.js";
 
 const PROVIDER_ID = "minimax-portal";
 const PROVIDER_LABEL = "MiniMax";
-const DEFAULT_MODEL = "MiniMax-M2.5";
+const DEFAULT_MODEL = "MiniMax-M2.7";
 const DEFAULT_BASE_URL_CN = "https://api.minimaxi.com/anthropic";
 const DEFAULT_BASE_URL_GLOBAL = "https://api.minimax.io/anthropic";
 const DEFAULT_CONTEXT_WINDOW = 200000;
@@ -78,6 +78,18 @@ function createOAuthHandler(region: MiniMaxRegion) {
                 api: "anthropic-messages",
                 models: [
                   buildModelDefinition({
+                    id: "MiniMax-M2.7",
+                    name: "MiniMax M2.7",
+                    input: ["text"],
+                    reasoning: true,
+                  }),
+                  buildModelDefinition({
+                    id: "MiniMax-M2.7-highspeed",
+                    name: "MiniMax M2.7 Highspeed",
+                    input: ["text"],
+                    reasoning: true,
+                  }),
+                  buildModelDefinition({
                     id: "MiniMax-M2.5",
                     name: "MiniMax M2.5",
                     input: ["text"],
@@ -101,6 +113,10 @@ function createOAuthHandler(region: MiniMaxRegion) {
           agents: {
             defaults: {
               models: {
+                [modelRef("MiniMax-M2.7")]: { alias: "minimax-m2.7" },
+                [modelRef("MiniMax-M2.7-highspeed")]: {
+                  alias: "minimax-m2.7-highspeed",
+                },
                 [modelRef("MiniMax-M2.5")]: { alias: "minimax-m2.5" },
                 [modelRef("MiniMax-M2.5-highspeed")]: {
                   alias: "minimax-m2.5-highspeed",

--- a/src/agents/live-model-filter.ts
+++ b/src/agents/live-model-filter.ts
@@ -23,7 +23,7 @@ const CODEX_MODELS = [
 ];
 const GOOGLE_PREFIXES = ["gemini-3"];
 const ZAI_PREFIXES = ["glm-5", "glm-4.7", "glm-4.7-flash", "glm-4.7-flashx"];
-const MINIMAX_PREFIXES = ["minimax-m2.5", "minimax-m2.5"];
+const MINIMAX_PREFIXES = ["minimax-m2.7", "minimax-m2.5"];
 const XAI_PREFIXES = ["grok-4"];
 
 function matchesPrefix(id: string, prefixes: string[]): boolean {

--- a/src/agents/models-config.providers.minimax.test.ts
+++ b/src/agents/models-config.providers.minimax.test.ts
@@ -36,14 +36,18 @@ describe("minimax provider catalog", () => {
 
     const providers = await resolveImplicitProvidersForTest({ agentDir });
     expect(providers?.minimax?.models?.map((model) => model.id)).toEqual([
-      "MiniMax-VL-01",
+      "MiniMax-M2.7",
+      "MiniMax-M2.7-highspeed",
       "MiniMax-M2.5",
-      "MiniMax-M2.5-highspeed",
+      "MiniMax-M2.5-Lightning",
+      "MiniMax-M2.1",
+      "MiniMax-M2.1-lightning",
+      "MiniMax-VL-01",
     ]);
     expect(providers?.["minimax-portal"]?.models?.map((model) => model.id)).toEqual([
-      "MiniMax-VL-01",
+      "MiniMax-M2.7",
+      "MiniMax-M2.7-highspeed",
       "MiniMax-M2.5",
-      "MiniMax-M2.5-highspeed",
     ]);
   });
 });

--- a/src/agents/models-config.providers.static.ts
+++ b/src/agents/models-config.providers.static.ts
@@ -36,7 +36,7 @@ type ProviderConfig = NonNullable<ModelsConfig["providers"]>[string];
 type ProviderModelConfig = NonNullable<ProviderConfig["models"]>[number];
 
 const MINIMAX_PORTAL_BASE_URL = "https://api.minimax.io/anthropic";
-const MINIMAX_DEFAULT_MODEL_ID = "MiniMax-M2.5";
+const MINIMAX_DEFAULT_MODEL_ID = "MiniMax-M2.7";
 const MINIMAX_DEFAULT_VISION_MODEL_ID = "MiniMax-VL-01";
 const MINIMAX_DEFAULT_CONTEXT_WINDOW = 200000;
 const MINIMAX_DEFAULT_MAX_TOKENS = 8192;
@@ -156,6 +156,16 @@ export function buildMinimaxProvider(): ProviderConfig {
     api: "anthropic-messages",
     authHeader: true,
     models: [
+      buildMinimaxTextModel({
+        id: "MiniMax-M2.7",
+        name: "MiniMax M2.7",
+        reasoning: true,
+      }),
+      buildMinimaxTextModel({
+        id: "MiniMax-M2.7-highspeed",
+        name: "MiniMax M2.7 Highspeed",
+        reasoning: true,
+      }),
       buildMinimaxModel({
         id: MINIMAX_DEFAULT_VISION_MODEL_ID,
         name: "MiniMax VL 01",
@@ -182,6 +192,16 @@ export function buildMinimaxPortalProvider(): ProviderConfig {
     api: "anthropic-messages",
     authHeader: true,
     models: [
+      buildMinimaxTextModel({
+        id: MINIMAX_DEFAULT_MODEL_ID,
+        name: "MiniMax M2.7",
+        reasoning: true,
+      }),
+      buildMinimaxTextModel({
+        id: "MiniMax-M2.7-highspeed",
+        name: "MiniMax M2.7 Highspeed",
+        reasoning: true,
+      }),
       buildMinimaxModel({
         id: MINIMAX_DEFAULT_VISION_MODEL_ID,
         name: "MiniMax VL 01",
@@ -189,7 +209,7 @@ export function buildMinimaxPortalProvider(): ProviderConfig {
         input: ["text", "image"],
       }),
       buildMinimaxTextModel({
-        id: MINIMAX_DEFAULT_MODEL_ID,
+        id: "MiniMax-M2.5",
         name: "MiniMax M2.5",
         reasoning: true,
       }),

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -40,7 +40,7 @@ type ModelsConfig = NonNullable<OpenClawConfig["models"]>;
 export type ProviderConfig = NonNullable<ModelsConfig["providers"]>[string];
 
 const MINIMAX_PORTAL_BASE_URL = "https://api.minimax.io/anthropic";
-const MINIMAX_DEFAULT_MODEL_ID = "MiniMax-M2.1";
+const MINIMAX_DEFAULT_MODEL_ID = "MiniMax-M2.7";
 const MINIMAX_DEFAULT_VISION_MODEL_ID = "MiniMax-VL-01";
 const MINIMAX_DEFAULT_CONTEXT_WINDOW = 200000;
 const MINIMAX_DEFAULT_MAX_TOKENS = 8192;
@@ -570,6 +570,26 @@ function buildMinimaxProvider(): ProviderConfig {
     models: [
       buildMinimaxTextModel({
         id: MINIMAX_DEFAULT_MODEL_ID,
+        name: "MiniMax M2.7",
+        reasoning: true,
+      }),
+      buildMinimaxTextModel({
+        id: "MiniMax-M2.7-highspeed",
+        name: "MiniMax M2.7 Highspeed",
+        reasoning: true,
+      }),
+      buildMinimaxTextModel({
+        id: "MiniMax-M2.5",
+        name: "MiniMax M2.5",
+        reasoning: true,
+      }),
+      buildMinimaxTextModel({
+        id: "MiniMax-M2.5-Lightning",
+        name: "MiniMax M2.5 Lightning",
+        reasoning: true,
+      }),
+      buildMinimaxTextModel({
+        id: "MiniMax-M2.1",
         name: "MiniMax M2.1",
         reasoning: false,
       }),
@@ -584,16 +604,6 @@ function buildMinimaxProvider(): ProviderConfig {
         reasoning: false,
         input: ["text", "image"],
       }),
-      buildMinimaxTextModel({
-        id: "MiniMax-M2.5",
-        name: "MiniMax M2.5",
-        reasoning: true,
-      }),
-      buildMinimaxTextModel({
-        id: "MiniMax-M2.5-Lightning",
-        name: "MiniMax M2.5 Lightning",
-        reasoning: true,
-      }),
     ],
   };
 }
@@ -605,8 +615,13 @@ function buildMinimaxPortalProvider(): ProviderConfig {
     models: [
       buildMinimaxTextModel({
         id: MINIMAX_DEFAULT_MODEL_ID,
-        name: "MiniMax M2.1",
-        reasoning: false,
+        name: "MiniMax M2.7",
+        reasoning: true,
+      }),
+      buildMinimaxTextModel({
+        id: "MiniMax-M2.7-highspeed",
+        name: "MiniMax M2.7 Highspeed",
+        reasoning: true,
       }),
       buildMinimaxTextModel({
         id: "MiniMax-M2.5",

--- a/src/commands/auth-choice.apply.minimax.test.ts
+++ b/src/commands/auth-choice.apply.minimax.test.ts
@@ -110,7 +110,7 @@ describe("applyAuthChoiceMiniMax", () => {
       token: "mm-opts-token",
       profileId: "minimax:default",
       provider: "minimax",
-      expectedModel: "minimax/MiniMax-M2.5",
+      expectedModel: "minimax/MiniMax-M2.7",
     },
     {
       caseName:
@@ -120,7 +120,7 @@ describe("applyAuthChoiceMiniMax", () => {
       token: "mm-cn-opts-token",
       profileId: "minimax-cn:default",
       provider: "minimax-cn",
-      expectedModel: "minimax-cn/MiniMax-M2.5",
+      expectedModel: "minimax-cn/MiniMax-M2.7",
     },
   ])(
     "$caseName",
@@ -182,7 +182,7 @@ describe("applyAuthChoiceMiniMax", () => {
         mode: "api_key",
       });
       expect(resolveAgentModelPrimaryValue(result?.config.agents?.defaults?.model)).toBe(
-        "minimax-cn/MiniMax-M2.5",
+        "minimax-cn/MiniMax-M2.7",
       );
     }
     expect(text).not.toHaveBeenCalled();
@@ -212,7 +212,7 @@ describe("applyAuthChoiceMiniMax", () => {
       mode: "api_key",
     });
     expect(resolveAgentModelPrimaryValue(result?.config.agents?.defaults?.model)).toBe(
-      "minimax/MiniMax-M2.5-highspeed",
+      "minimax/MiniMax-M2.7-highspeed",
     );
     expect(text).not.toHaveBeenCalled();
     expect(confirm).not.toHaveBeenCalled();

--- a/src/commands/auth-choice.apply.minimax.ts
+++ b/src/commands/auth-choice.apply.minimax.ts
@@ -112,7 +112,7 @@ export async function applyAuthChoiceMiniMax(
       promptMessage: "Enter MiniMax API key",
       modelRefPrefix: "minimax",
       modelId:
-        params.authChoice === "minimax-api-lightning" ? "MiniMax-M2.5-highspeed" : "MiniMax-M2.5",
+        params.authChoice === "minimax-api-lightning" ? "MiniMax-M2.7-highspeed" : "MiniMax-M2.7",
       applyDefaultConfig: applyMinimaxApiConfig,
       applyProviderConfig: applyMinimaxApiProviderConfig,
     });
@@ -124,7 +124,7 @@ export async function applyAuthChoiceMiniMax(
       provider: "minimax-cn",
       promptMessage: "Enter MiniMax China API key",
       modelRefPrefix: "minimax-cn",
-      modelId: "MiniMax-M2.5",
+      modelId: "MiniMax-M2.7",
       applyDefaultConfig: applyMinimaxApiConfigCn,
       applyProviderConfig: applyMinimaxApiProviderConfigCn,
     });

--- a/src/commands/auth-choice.test.ts
+++ b/src/commands/auth-choice.test.ts
@@ -1276,7 +1276,7 @@ describe("applyAuthChoice", () => {
         profileId: "minimax-portal:default",
         baseUrl: "https://api.minimax.io/anthropic",
         api: "anthropic-messages",
-        defaultModel: "minimax-portal/MiniMax-M2.5",
+        defaultModel: "minimax-portal/MiniMax-M2.7",
         apiKey: "minimax-oauth", // pragma: allowlist secret
         selectValue: "oauth",
       },

--- a/src/commands/onboard-auth.config-minimax.ts
+++ b/src/commands/onboard-auth.config-minimax.ts
@@ -112,7 +112,7 @@ export function applyMinimaxHostedConfig(
 // MiniMax Anthropic-compatible API (platform.minimax.io/anthropic)
 export function applyMinimaxApiProviderConfig(
   cfg: OpenClawConfig,
-  modelId: string = "MiniMax-M2.5",
+  modelId: string = "MiniMax-M2.7",
 ): OpenClawConfig {
   return applyMinimaxApiProviderConfigWithBaseUrl(cfg, {
     providerId: "minimax",
@@ -123,7 +123,7 @@ export function applyMinimaxApiProviderConfig(
 
 export function applyMinimaxApiConfig(
   cfg: OpenClawConfig,
-  modelId: string = "MiniMax-M2.5",
+  modelId: string = "MiniMax-M2.7",
 ): OpenClawConfig {
   return applyMinimaxApiConfigWithBaseUrl(cfg, {
     providerId: "minimax",
@@ -135,7 +135,7 @@ export function applyMinimaxApiConfig(
 // MiniMax China API (api.minimaxi.com)
 export function applyMinimaxApiProviderConfigCn(
   cfg: OpenClawConfig,
-  modelId: string = "MiniMax-M2.5",
+  modelId: string = "MiniMax-M2.7",
 ): OpenClawConfig {
   return applyMinimaxApiProviderConfigWithBaseUrl(cfg, {
     providerId: "minimax-cn",
@@ -146,7 +146,7 @@ export function applyMinimaxApiProviderConfigCn(
 
 export function applyMinimaxApiConfigCn(
   cfg: OpenClawConfig,
-  modelId: string = "MiniMax-M2.5",
+  modelId: string = "MiniMax-M2.7",
 ): OpenClawConfig {
   return applyMinimaxApiConfigWithBaseUrl(cfg, {
     providerId: "minimax-cn",

--- a/src/commands/onboard-auth.models.ts
+++ b/src/commands/onboard-auth.models.ts
@@ -17,7 +17,7 @@ export {
 export const DEFAULT_MINIMAX_BASE_URL = "https://api.minimax.io/v1";
 export const MINIMAX_API_BASE_URL = "https://api.minimax.io/anthropic";
 export const MINIMAX_CN_API_BASE_URL = "https://api.minimaxi.com/anthropic";
-export const MINIMAX_HOSTED_MODEL_ID = "MiniMax-M2.5";
+export const MINIMAX_HOSTED_MODEL_ID = "MiniMax-M2.7";
 export const MINIMAX_HOSTED_MODEL_REF = `minimax/${MINIMAX_HOSTED_MODEL_ID}`;
 export const DEFAULT_MINIMAX_CONTEXT_WINDOW = 200000;
 export const DEFAULT_MINIMAX_MAX_TOKENS = 8192;
@@ -89,6 +89,8 @@ export const ZAI_DEFAULT_COST = {
 };
 
 const MINIMAX_MODEL_CATALOG = {
+  "MiniMax-M2.7": { name: "MiniMax M2.7", reasoning: true },
+  "MiniMax-M2.7-highspeed": { name: "MiniMax M2.7 Highspeed", reasoning: true },
   "MiniMax-M2.5": { name: "MiniMax M2.5", reasoning: true },
   "MiniMax-M2.5-highspeed": { name: "MiniMax M2.5 Highspeed", reasoning: true },
 } as const;

--- a/src/commands/onboard-auth.test.ts
+++ b/src/commands/onboard-auth.test.ts
@@ -412,7 +412,7 @@ describe("applyMinimaxApiConfig", () => {
     expect(cfg.models?.providers?.minimax?.apiKey).toBe("old-key");
     expect(cfg.models?.providers?.minimax?.models.map((m) => m.id)).toEqual([
       "old-model",
-      "MiniMax-M2.5",
+      "MiniMax-M2.7",
     ]);
   });
 

--- a/src/commands/onboard-non-interactive.provider-auth.test.ts
+++ b/src/commands/onboard-non-interactive.provider-auth.test.ts
@@ -190,7 +190,7 @@ describe("onboard (non-interactive): provider auth", () => {
       expect(cfg.auth?.profiles?.["minimax:default"]?.provider).toBe("minimax");
       expect(cfg.auth?.profiles?.["minimax:default"]?.mode).toBe("api_key");
       expect(cfg.models?.providers?.minimax?.baseUrl).toBe(MINIMAX_API_BASE_URL);
-      expect(cfg.agents?.defaults?.model?.primary).toBe("minimax/MiniMax-M2.5");
+      expect(cfg.agents?.defaults?.model?.primary).toBe("minimax/MiniMax-M2.7");
       await expectApiKeyProfile({
         profileId: "minimax:default",
         provider: "minimax",
@@ -209,7 +209,7 @@ describe("onboard (non-interactive): provider auth", () => {
       expect(cfg.auth?.profiles?.["minimax-cn:default"]?.provider).toBe("minimax-cn");
       expect(cfg.auth?.profiles?.["minimax-cn:default"]?.mode).toBe("api_key");
       expect(cfg.models?.providers?.["minimax-cn"]?.baseUrl).toBe(MINIMAX_CN_API_BASE_URL);
-      expect(cfg.agents?.defaults?.model?.primary).toBe("minimax-cn/MiniMax-M2.5");
+      expect(cfg.agents?.defaults?.model?.primary).toBe("minimax-cn/MiniMax-M2.7");
       await expectApiKeyProfile({
         profileId: "minimax-cn:default",
         provider: "minimax-cn",


### PR DESCRIPTION
## Summary
Upgrade MiniMax model configuration to include the latest M2.7 model as default.

## Changes
- Add MiniMax-M2.7 and MiniMax-M2.7-highspeed to the model selection list
- Set MiniMax-M2.7 as the new default model
- Retain all previous models as available alternatives
- Update related unit tests
- Update documentation (provider docs, FAQ, gateway config examples)

## Why
MiniMax-M2.7 is the latest flagship model with enhanced reasoning and coding capabilities.

Release notes:
- EN: https://www.minimax.io/news/minimax-m27-en
- ZH: https://www.minimaxi.com/news/minimax-m27-zh

## Files Changed (16 files, 140 additions, 85 deletions)

### Core model definitions
- `src/agents/models-config.providers.ts` — Add M2.7 models, update default
- `src/agents/models-config.providers.static.ts` — Add M2.7 models, update default
- `src/commands/onboard-auth.models.ts` — Update model catalog and hosted model ID
- `extensions/minimax-portal-auth/index.ts` — Add M2.7 models and aliases, update default

### Auth/config
- `src/commands/auth-choice.apply.minimax.ts` — Update default model IDs
- `src/commands/onboard-auth.config-minimax.ts` — Update default parameters
- `src/agents/live-model-filter.ts` — Add M2.7 prefix

### Tests
- `src/agents/models-config.providers.minimax.test.ts` — Update model list expectations
- `src/commands/auth-choice.apply.minimax.test.ts` — Update default model assertions
- `src/commands/auth-choice.test.ts` — Update portal default model
- `src/commands/onboard-auth.test.ts` — Update merged model expectations
- `src/commands/onboard-non-interactive.provider-auth.test.ts` — Update primary model assertions

### Documentation
- `docs/providers/minimax.md` — Update model overview, examples, troubleshooting
- `docs/help/faq.md` — Update model references
- `docs/gateway/configuration-reference.md` — Update config examples
- `docs/gateway/configuration-examples.md` — Update fallback examples

## Testing
- Unit tests updated and passing
- Pre-existing test failures (unrelated to MiniMax) remain unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **文档**
  * 更新 MiniMax 配置示例、参考文档和常见问题，反映最新模型版本

* **配置更新**
  * MiniMax 默认模型升级至 M2.7 版本
  * 新增 M2.7-highspeed 高速模型变体支持
  * 为新模型版本启用推理功能

* **测试**
  * 更新测试期望值以匹配新的模型配置

<!-- end of auto-generated comment: release notes by coderabbit.ai -->