### PR TITLE
feat: add browser-cdp skill for CDP-based browser automation

### DIFF
--- a/skills/browser-cdp/SKILL.md
+++ b/skills/browser-cdp/SKILL.md
@@ -20,10 +20,16 @@ This skill provides browser automation via a lightweight HTTP proxy that wraps C
 
 ## Prerequisites
 
-A CDP proxy must be running on `http://localhost:3456`. Start it with:
+Install the required Python dependency:
 
 ```bash
-python3 {baseDir}/scripts/cdp_proxy.py
+pip install psutil
+```
+
+A CDP proxy must be running on `http://localhost:3456`. Start it from the repository root with:
+
+```bash
+python3 skills/browser-cdp/scripts/cdp_proxy.py
 ```
 
 This launches Chrome/Edge with remote debugging enabled and proxies CDP commands over HTTP.
@@ -157,7 +163,7 @@ curl -s "http://localhost:3456/navigate?url=https://chromewebstore.google.com/se
 # Extract extension IDs from search results
 curl -s -X POST http://localhost:3456/eval \
   -H "Content-Type: text/plain" \
-  -d "JSON.stringify([...document.querySelectorAll('a[data-id]')].map(a => ({id: a.dataset.id, title: a.textContent.trim()}))])"
+  -d "JSON.stringify([...document.querySelectorAll('a[data-id]')].map(a => ({id: a.dataset.id, title: a.textContent.trim()})))"
 
 # Install an extension (requires the extension ID)
 curl -s "http://localhost:3456/navigate?url=https://chromewebstore.google.com/detail/<extension-id>"
@@ -186,7 +192,7 @@ curl -s "http://localhost:3456/click?selector=%23login-form+%3E+button"
 ## Notes
 
 - The CDP proxy must be running before using any commands
-- If the proxy is not running, ask the user to start it: `python3 {baseDir}/scripts/cdp_proxy.py`
+- If the proxy is not running, ask the user to start it: `python3 skills/browser-cdp/scripts/cdp_proxy.py`
 - Use URL encoding for query parameters with special characters
 - The `/eval` endpoint returns the result of the last expression (like a REPL)
 - Screenshots are returned as PNG binary data

--- a/skills/browser-cdp/scripts/cdp_proxy.py
+++ b/skills/browser-cdp/scripts/cdp_proxy.py
@@ -69,7 +69,7 @@ def find_chrome_path() -> Optional[str]:
                 timeout=5,
             )
             if proc.returncode == 0:
-                return path.strip()
+                return proc.stdout.strip()
         except (subprocess.TimeoutExpired, FileNotFoundError):
             continue
 
@@ -321,8 +321,15 @@ class CDPProxyHandler(BaseHTTPRequestHandler):
 
         try:
             resp = result.get("result", {})
-            inner = json.loads(resp.get("result", "{}"))
-            self._send_json({"result": inner.get("result", {}).get("value")})
+            inner = resp.get("result", {})
+            value = inner.get("value")
+            # If value is a JSON string (e.g. from JSON.stringify), parse it
+            if isinstance(value, str):
+                try:
+                    value = json.loads(value)
+                except json.JSONDecodeError:
+                    pass  # Return as plain string
+            self._send_json({"result": value})
         except Exception as e:
             self._send_json({"error": str(e)}, 500)
 
@@ -360,13 +367,19 @@ class CDPProxyHandler(BaseHTTPRequestHandler):
 
         try:
             resp = result.get("result", {})
-            inner = json.loads(resp.get("result", "{}"))
-            self._send_json(json.loads(inner.get("result", {}).get("value", "{}")))
+            inner = resp.get("result", {})
+            value = inner.get("value")
+            if isinstance(value, str):
+                try:
+                    value = json.loads(value)
+                except json.JSONDecodeError:
+                    pass
+            self._send_json(value)
         except Exception as e:
             self._send_json({"error": str(e)}, 500)
 
     def _handle_new_tab(self):
-        url = f"http://127.0.0.1:{self.server.debug_port}/json/new?about:blank"
+        url = f"http://127.0.0.1:{self.server.debug_port}/json/new?url=about:blank"
         try:
             with urllib.request.urlopen(url, timeout=10) as resp:
                 target = json.loads(resp.read().decode("utf-8"))


### PR DESCRIPTION
## Summary

Adds a new `browser-cdp` skill that enables agents to control a browser via Chrome DevTools Protocol (CDP) through a lightweight HTTP proxy.

## What's included

- `skills/browser-cdp/SKILL.md` — Full skill definition with trigger phrases, workflows, and API reference
- `skills/browser-cdp/scripts/cdp_proxy.py` — Self-contained CDP proxy server (~430 lines)

## Features

- **Full CDP proxy**: navigation, JavaScript evaluation, screenshots, clicks, form filling
- **Auto-discovery** of Chrome debugging ports (tries multiple known ports)
- **Session management** with tab tracking via `/targets`
- **No external dependencies** — Python stdlib only
- **REST-friendly** HTTP API wrapping CDP's WebSocket protocol

## Validation

Passed `quick_validate.py` from the skill-creator skill.

## Example usage

```
POST /eval
Body: document.title
→ "My Page"
```

```
GET /screenshot?target=page_1
→ PNG image
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增 browser-cdp 技能，支持通过本地 HTTP 代理控制真实浏览器进行导航、截图、执行 JavaScript、点击元素和管理标签页等操作。
* **文档**
  * 提供详尽使用说明、REST 接口说明及常见工作流示例（页面抓取、截图、扩展搜索/安装、表单交互等）。
* **其它**
  * 启动/关闭与错误处理行为在文档中有说明。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->